### PR TITLE
Add build_ezbake shared action

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -1,0 +1,61 @@
+name: Build an OpenVox ezbake project
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Tag to build'
+        required: true
+        type: string
+      deb_platform_list:
+        description: 'A comma-separated list of deb-based platforms to build for, excluding the architecture (e.g. ubuntu-24.04,debian-12). Do not include spaces. If not provided, will use the default list of platforms supported by OpenVox Server and DB.'
+        required: false
+        type: string
+      rpm_platform_list:
+        description: 'A comma-separated list of rpm-based platforms to build for, excluding the architecture (e.g. el-9,amazon-2023). Do not include spaces. If not provided, will use the default list of platforms supported by OpenVox Server and DB.'
+        required: false
+        type: string
+
+env:
+  ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+  BUCKET_NAME: ${{ secrets.S3_ARTIFACTS_BUCKET_NAME }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
+  AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
+  AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
+  DEB_PLATFORMS: ${{ inputs.deb_platform_list || 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,debian-10,debian-11,debian-12' }}
+  RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'el-7,el-8,el-9,el-10,sles-15,amazon-2023' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 600
+    strategy:
+      fail-fast: false
+    steps:
+      # This always checks out main, because the vox:build task will check
+      # out the tag itself.
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.6'
+          bundler-cache: true
+
+      - name: Update awscli
+        run: |
+          python -m pip install --upgrade awscli
+
+      - name: Run build script
+        run: |
+          rm -rf output
+          bundle exec rake vox:build['${{ inputs.ref }}']
+
+      - name: Upload output to S3
+        run: |
+          bundle exec rake vox:upload['${{ inputs.ref }}']


### PR DESCRIPTION
This one works a little differently from build_vanagon. Because we can build every platform on the same host (the packages are noarch, the resulting deb/rpms are basically all the same save for some metadata), we don't need to worry about x86 vs. arm runners. The vox:build task will (shortly) accept a list of deb and rpm platforms via environment variables.