### PR TITLE
Update build_vanagon to remove qemu and bump Ruby

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -99,13 +99,8 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.6'
+          ruby-version: '3.2.7'
           bundler-cache: true
-
-      - name: Install qemu-user-static
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y qemu-user-static
 
       - name: Update awscli
         run: |


### PR DESCRIPTION
We no longer need qemu since we are using runners that have the same arch we are building for. Also bumps Ruby to 3.2.7.