### PR TITLE
Add prepare_release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,104 @@
+---
+name: 'Prepare Release'
+
+on:
+  workflow_call:
+    inputs:
+      allowed_owner:
+        description: 'Only allow this owner'
+        required: true
+        type: string
+      version:
+        description: 'Version to be released.'
+        required: false
+        default: ''
+        type: string
+      base-branch:
+        description: 'The branch that will be used as the origin for the release branch.'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      github_pat:
+        # Provide a fine-grained token with the following repository permissions:
+        # * Contents: Read and write
+        # * Metadata: Read-only (mandatory, default)
+        # * Pull requests: Read and write
+        description: 'The token used to interact with GitHub'
+        required: true
+      ssh_private_key:
+        description: 'The SSH private key used to sign commits and tags.'
+        required: true
+
+env:
+  GIT_AUTHOR_NAME: OpenVoxProjectBot
+  GIT_AUTHOR_EMAIL: 215568489+OpenVoxProjectBot@users.noreply.github.com
+  GIT_COMMITTER_NAME: OpenVoxProjectBot
+  GIT_COMMITTER_EMAIL: 215568489+OpenVoxProjectBot@users.noreply.github.com
+  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
+jobs:
+  prepare_release:
+    name: 'Prepare Release'
+    environment: release
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == inputs.allowed_owner
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base-branch }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Add SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.ssh_private_key }}" > ~/.ssh/github_actions
+          chmod 600 ~/.ssh/github_actions
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add ~/.ssh/github_actions
+
+      - name: Setup git
+        run: |
+          git config --global user.email "$GIT_AUTHOR_EMAIL"
+          git config --global user.name "$GIT_AUTHOR_NAME"
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/github_actions
+          git config --global commit.gpgsign true
+          git config --global tag.gpgsign true
+
+      - name: Display bundle environment
+        run: |
+          bundle env
+
+      - name: Update to new version
+        run: |
+          bundle exec rake vox:version:bump:full[${{ inputs.version }}]
+
+      - name: Prepare the release
+        env:
+          # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+          CHANGELOG_GITHUB_TOKEN: '${{ secrets.github_pat }}'
+        run: bundle exec rake release:prepare
+
+      - name: Create pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Release ${{ inputs.version }}"
+          branch: "release-${{ inputs.version }}"
+          delete-branch: true
+          title: "Release ${{ inputs.version }}"
+          labels: skip-changelog
+          token: '${{ secrets.github_pat }}'
+          assignees: '${{ github.triggering_actor }}'
+          author: '${{ env.GIT_AUTHOR_NAME }} <${{ env.GIT_AUTHOR_EMAIL }}>'
+          committer: '${{ env.GIT_COMMITTER_NAME }} <${{ env.GIT_COMMITTER_EMAIL }}>'
+          body: |
+            Automated release-prep through https://github.com/OpenVoxProject/shared-actions/ from commit ${{ github.sha }}.


### PR DESCRIPTION
This is intended to be used in the various OpenVox projects to provide a unified way to prepare a new release.

It is intended to deprecate the `vox:tag` task and offer a workflow that is triggered manually to prepare a new release. This workflow use two rake tasks to prepare the release:

* `vox:version:bump:full[version]` to update the version (this is a stripped-down version of what the `vox:tag` task did: only update the version, but do not commit the change / tag them / push);
* `release:prepare` to perform last minute actions.  This can be used for example to generate a ChangeLog.

When this is done, a PR is opened for review.

This workflow has been tested in https://github.com/OpenVoxProject/gha-test/, feel free to mess with this repository for testing / review.