### PR TITLE
Include the 'release' group in bundles for release actions

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -36,6 +36,7 @@ env:
   GIT_COMMITTER_NAME: OpenVoxProjectBot
   GIT_COMMITTER_EMAIL: 215568489+OpenVoxProjectBot@users.noreply.github.com
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+  BUNDLE_WITH: release
 
 jobs:
   prepare_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ env:
   GIT_COMMITTER_NAME: OpenVoxProjectBot
   GIT_COMMITTER_EMAIL: 215568489+OpenVoxProjectBot@users.noreply.github.com
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+  BUNDLE_WITH: release
 
 jobs:
   release:


### PR DESCRIPTION
When preparing a release or releasing, we may need tooling in the
release group of the Gemfile.  This group may be optional, which mean it
is not included by default, so explicitly request it.
