### PR TITLE
Validate Semantic Version syntax on release preparation

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository_owner == inputs.allowed_owner
     steps:
+      - name: Make sure inputs.version looks like a valid Semantic Version
+        run: |
+          echo "${{ inputs.version }}" | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)?$'
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The release preparation task in liberal in the input it accept and pass it directly to the underlying (project specific) to bump the version.

These underlying projects seems to also be liberal in what they accept, and we already ended-up releasing pre-release gems with an invalid version number according to SemVer (`<major>.<minor>.<path>.<pre-release>` instead of `<major>.<minor>.<patch>-<pre-release>`).

I feel like ruby does some magic with version numbers (i.e. `Gem::Version.new('5.0.0-rc1').to_s #=> "5.0.0.pre.rc1"`), so it is probably not a big deal, but the tag name and the version in the PR should really follow semver as we tell our consumers that it is what we
use.
