### PR TITLE
Add a reusable workflow for Beaker acceptance

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -1,0 +1,441 @@
+name: Run Beaker acceptance tests on an OpenVox project
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: |-
+          The git ref of the project-name Beaker test suite to run.
+        required: true
+        type: string
+      project-name:
+        description: The OpenVox project to test.
+        required: true
+        type: string
+      install-openvox:
+        description: |-
+          Whether or not to install any openvox packages on the
+          virtual machines created for the tests.
+
+          If true, then openvox-agent packages will be installed on
+          all nodes listed in the vms input, and openvox-server and
+          openvoxdb packages may be installed depending on the
+          install-openvox-server and install-openvoxdb flags, and on
+          whether the vms input has a node in the 'primary' role.
+
+          If false, then no openvox packages will be installed,
+          regardless of the install-openvox-server or
+          install-openvoxdb flags.
+        required: false
+        type: boolean
+        default: true
+      openvox-collection:
+        description: |-
+          The OpenVox collection to install from.
+        required: false
+        type: string
+        default: openvox8
+      openvox-agent-version:
+        description: |-
+          The version of the openvox-agent package to install.
+        required: false
+        type: string
+      openvox-agent-pre-release-build:
+        description: |-
+          Whether to test unreleased openvox-agent-version packages
+          from the artifacts-url server, or released packages from the
+          given openvox-collection.
+
+          If this is true, openvox-agent-version must be a valid
+          version, not latest, and openvox-collection is ignored. The
+          workflow will download and install the matching
+          openvox-agent package file from the artifacts-url server.
+
+          If this is false, openvox-agent-version and
+          openvox-collection must match, and the workflow will install
+          the given openvox collection package and then let the system
+          package manager install the latest or openvox-agent-version
+          package from the collection repository.
+        required: false
+        type: boolean
+        default: true
+      install-openvox-server:
+        description: |-
+          If true, the openvox-server package will be installed on any
+          node in vms with the role 'primary'.
+        required: false
+        type: boolean
+        default: true
+      openvox-server-version:
+        description: |-
+          The version of the openvox-server package to install.
+        required: false
+        type: string
+      openvox-server-pre-release-build:
+        description: |-
+          Whether to test unreleased openvox-server-version packages
+          from the artifacts-url server, or released packages from the
+          given openvox-collection.
+
+          (See openvox-agent-pre-release-build)
+        required: false
+        type: boolean
+        default: true
+      install-openvoxdb:
+        description: |-
+          If true, the openvoxdb package will be installed on any node
+          in vms with the role 'primary'.
+        required: false
+        type: boolean
+        default: false
+      openvoxdb-version:
+        description: |-
+          The version of the openvoxdb package to install.
+        required: false
+        type: string
+      openvoxdb-pre-release-build:
+        description: |-
+          Whether to test unreleased openvoxdb-version packages
+          from the artifacts-url server, or released packages from the
+          given openvox-collection.
+
+          (See openvox-agent-pre-release-build)
+        required: false
+        type: boolean
+        default: true
+      install-openvoxdb-termini:
+        description: |-
+          In a production installation using openvoxdb, the
+          openvoxdb-termini package is installed alongside
+          openvox-server. Set this to false to install just
+          openvox-server without the openvoxdb-termini.
+        required: false
+        type: boolean
+        default: true
+      artifacts-url:
+        description: |-
+          URL to the artifacts server. This is used to download
+          pre-release packages for openvox-agent, openvox-server, and
+          openvoxdb if their pre-release-build inputs are true.
+        required: false
+        type: string
+        default: 'https://s3.osuosl.org/openvox-artifacts'
+      ruby-version:
+        description: |-
+          The Ruby version to use for the project being tested.
+          This is used to install Ruby and run Bundler when
+          running the project's Beaker acceptance suite.
+        required: false
+        type: string
+        default: '3.3'
+      acceptance-working-dir:
+        description: |-
+          The working directory for the acceptance tests, relative to
+          project root.
+        required: false
+        type: string
+        default: 'acceptance'
+      acceptance-pre-suite:
+        description: |-
+          JSON array of Beaker pre-suite files to run.
+          These should be relative to the acceptance-working-dir, or
+          absolute paths.
+          If not provided, no pre-suite will be run.
+        required: false
+        type: string
+        default: '[]'
+      acceptance-tests:
+        description: |-
+          JSON array of Beaker test files to run.
+          These should be relative to the acceptance-working-dir, or
+          absolute paths.
+          If not provided, no tests will be run.
+        required: false
+        type: string
+        default: '[]'
+      beaker-options:
+        description: |-
+          A JSON hash of Beaker options to be included in the
+          .beaker.yml generated for the test suite run.
+
+          This is useful for setting details like 'helper', 'load_path'
+          and 'options_file', among others.
+        required: false
+        type: string
+        default: '{}'
+      os:
+        description: |-
+          JSON array of operating systems to run the tests on.
+          Each entry is an array of minimally [os, os-version],
+          with os-arch and image_version as optional third and fourth
+          elements.
+
+          The elements are passed to jpartlow/nested_vms os,
+          os-version, os-arch and image_version inputs.
+
+          Ex:
+            [
+              ["almalinux", "8"],
+              ["debian", "12", "amd64", "daily-latest"]
+            ]
+
+          Generally the default array can be used, and
+          additional operating systems can be specified with the
+          os-add parameter.
+        required: false
+        type: string
+        default: |-
+          [
+            ["almalinux", "8"],
+            ["almalinux", "9"],
+            ["debian", "11"],
+            ["debian", "12"],
+            ["rocky", "8"],
+            ["rocky", "9"],
+            ["ubuntu", "18.04"],
+            ["ubuntu", "20.04"],
+            ["ubuntu", "22.04"],
+            ["ubuntu", "24.04"]
+          ]
+      os-add:
+        description: |-
+          Additional operating systems to run the tests on.
+          This is a JSON array of the same format as the os input.
+          If provided, these will be added to the end of the os matrix.
+        required: false
+        type: string
+        default: '[]'
+      vms:
+        description: |-
+          JSON array of virtual machine descriptions to create for the
+          tests. This is passed to the jpartlow/nested_vms action and
+          is in a format handled by jpartlow/kvm_automation_tooling's
+          standup_cluster plan.
+
+          Each entry is an object with the following properties:
+          - role: The role of the VM (e.g., "agent").
+          - count: The number of VMs to create for this role.
+          - cpus: The number of CPUs to allocate to each VM.
+          - mem_mb: The amount of memory (in MB) to allocate to each VM.
+          - disk_gb: The amount of disk space (in GB) to allocate to
+            each VM.
+          - cpu_mode: The CPU mode to use for the VM (e.g.,
+            "host-model"). (Necessary for el-9 which expects at least
+            x86_64-2 arch, and depends on the runner's architecture
+            being sufficient.)
+        required: false
+        type: string
+        default: |-
+          [
+            {
+              "role": "agent",
+              "count": 1,
+              "cpus": 2,
+              "mem_mb": 4096,
+              "cpu_mode": "host-model"
+            }
+          ]
+
+env:
+  # Suppress warnings about Bolt gem versus package use.
+  BOLT_GEM: true
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      os-matrix: ${{ steps.set-matrix.outputs.os_matrix }}
+    steps:
+      - id: set-matrix
+        env:
+          OS: ${{ inputs.os }}
+          OS_ADD: ${{ inputs.os-add }}
+        run: |-
+          cat > matrix_inputs.json <<EOF
+          [
+            ${OS},
+            ${OS_ADD}
+          ]
+          EOF
+          cat matrix_inputs.json
+          echo "os_matrix=$(jq --monochrome-output --compact-output 'add | unique' matrix_inputs.json)" >> $GITHUB_OUTPUT
+
+  acceptance:
+    name: Acceptance Tests
+    needs: set-matrix
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.set-matrix.outputs.os-matrix) }}
+    env:
+      ACCEPTANCE_WORKING_DIR: |-
+        ${{ format('{0}/{1}/{2}',
+                   github.workspace,
+                   inputs.project-name,
+                   inputs.acceptance-working-dir) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: ${{ inputs.project-name }}
+
+      - id: vm-cluster
+        uses: jpartlow/nested_vms@v1
+        with:
+          os: ${{ matrix.os[0] }}
+          os-version: ${{ matrix.os[1] }}
+          os-arch: ${{ matrix.os[2] || 'x86_64' }}
+          image_version: ${{ matrix.os[3] }}
+          host-root-access: true
+          install-openvox: false
+          # Note: the cpu_mode is set to host-model for the sake of
+          # el-9 which expects at least x86_64-2 arch. This depends on
+          # the runner's architecture being sufficient, and there is
+          # probably a better way to get this set on the libvirt
+          # domain instead.
+          vms: ${{ inputs.vms }}
+
+      - name: Write Install OpenVox Params
+        working-directory: kvm_automation_tooling
+        if: ${{ inputs.install-openvox == true }}
+        env:
+          OPENVOX_ARTIFACTS_URL: |-
+            ${{ inputs.artifacts-url }}
+          OPENVOX_COLLECTION: ${{ inputs.collection }}
+          OPENVOX_AGENT_VERSION: |-
+            ${{ ((inputs.openvox-agent-version == '') && 'latest') ||
+                 inputs.openvox-agent-version }}
+          OPENVOX_AGENT_RELEASED: |-
+            ${{ !inputs.openvox-agent-pre-release-build }}
+          OPENVOX_SERVER_TARGETS: |-
+            ${{ ((inputs.install-openvox-server == true) && '"primary"') ||
+                  '[]' }}
+          OPENVOX_SERVER_VERSION: |-
+            ${{ ((inputs.openvox-server-version == '') && 'latest') ||
+                 inputs.openvox-server-version }}
+          OPENVOX_SERVER_RELEASED: |-
+            ${{ !inputs.openvox-server-pre-release-build }}
+          OPENVOX_DB_TARGETS: |-
+            ${{ ((inputs.install-openvoxdb == true) && '"primary"') ||
+                 '[]' }}
+          OPENVOX_DB_VERSION: |-
+            ${{ ((inputs.openvoxdb-version == '') && 'latest') ||
+                 inputs.openvoxdb-version }}
+          OPENVOX_DB_RELEASED: |-
+            ${{ !inputs.openvoxdb-pre-release-build }}
+          INSTALL_TERMINI: ${{ inputs.install-openvoxdb-termini }}
+        run: |-
+          cat > install_openvox_params.json <<EOF
+          {
+            "openvox_agent_targets": "all",
+            "openvox_server_targets": ${OPENVOX_SERVER_TARGETS},
+            "openvox_db_targets": ${OPENVOX_DB_TARGETS},
+            "openvox_agent_params": {
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_version": "${OPENVOX_AGENT_VERSION}",
+              "openvox_released": ${OPENVOX_AGENT_RELEASED}
+            },
+            "openvox_server_params": {
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_version": "${OPENVOX_SERVER_VERSION}",
+              "openvox_released": ${OPENVOX_SERVER_RELEASED}
+            },
+            "openvox_db_params": {
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_version": "${OPENVOX_DB_VERSION}",
+              "openvox_released": ${OPENVOX_DB_RELEASED}
+            },
+            "install_defaults": {
+              "openvox_version": "latest",
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_released": true,
+              "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
+            },
+            "install_termini": ${INSTALL_TERMINI}
+          }
+          EOF
+          cat install_openvox_params.json
+
+      - name: Install OpenVox Components
+        working-directory: kvm_automation_tooling
+        if: ${{ inputs.install-openvox == true }}
+        env:
+          # Generated by the nested_vms action.
+          INVENTORY: terraform/instances/inventory.test.yaml
+        run: |-
+          bundle exec bolt plan run \
+            kvm_automation_tooling::install_openvox \
+            --inventory "${INVENTORY}" \
+            --params @install_openvox_params.json
+
+      - name: Construct hosts.yaml
+        working-directory: kvm_automation_tooling
+        env:
+          HOSTS_YAML: ${{ env.ACCEPTANCE_WORKING_DIR }}/hosts.yaml
+          # Generated by the nested_vms action.
+          INVENTORY: terraform/instances/inventory.test.yaml
+        run: |-
+          bundle exec bolt plan run \
+            kvm_automation_tooling::dev::generate_beaker_hosts_file \
+            --inventory "${INVENTORY}" \
+            hosts_yaml="${HOSTS_YAML}"
+          cat "${HOSTS_YAML}"
+
+      - name: Install Ruby and Run Bundler for Acceptance Tests
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby-version }}
+          working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
+          bundler-cache: true
+
+      - name: Write .beaker.yml
+        working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
+        # for pipefail
+        shell: bash
+        env:
+          # Generated by the nested_vms action.
+          SSH_KEY: ~/.ssh/ssh-id-test
+          PRE_SUITE_ARRAY: |-
+            ${{ inputs.acceptance-pre-suite || '[]' }}
+          TESTS_ARRAY: |-
+            ${{ inputs.acceptance-tests || '[]' }}
+          BEAKER_OPTIONS: |-
+            ${{ inputs.beaker-options || '{}' }}
+        run: |-
+          cat > beaker.yml.inputs <<EOF
+          [
+            {
+              "ssh": {
+                "keys": [
+                  "${SSH_KEY}"
+                ]
+              },
+              "xml":                       true,
+              "timesync":                  false,
+              "repo_proxy":                true,
+              "add_el_extras":             false,
+              "master-start-curl-retries": 30,
+              "log_level":                 "debug",
+              "preserve_hosts":            "always",
+              "type":                      "aio",
+              "pre_suite": ${PRE_SUITE_ARRAY},
+              "tests": ${TESTS_ARRAY}
+            },
+            ${BEAKER_OPTIONS}
+          ]
+          EOF
+          cat beaker.yml.inputs
+          jq 'add' beaker.yml.inputs | yq -P > .beaker.yml
+          cat .beaker.yml
+
+      - name: Run Beaker
+        working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
+        run: |-
+          # Options feed in from .beaker.yml generated above
+          bundle exec beaker init --hosts hosts.yaml
+          # The provision step is still needed here, see notes in the
+          # kvm_automation_tooling/templates/beaker-hosts.yaml.epp
+          # template...
+          bundle exec beaker provision
+          bundle exec beaker exec

--- a/README.md
+++ b/README.md
@@ -23,3 +23,31 @@ The two actions do things a little bit differently.
 - `/.github/workflows/sync.yml`
   - This one is far simpler. It relies on the user to have manually cloned each repo and set up the plumbing branch.
   - It basically just does a `git fetch` and a `git push` and creates the backup branches.
+
+### Beaker Acceptance action:
+
+The `/.github/workflows/beaker_acceptance.yml` is a reusable workflow
+for [Beaker](https://github.com/voxpupuli/beaker) acceptance of
+OpenVox projects.
+
+It:
+
+* checks out the given project-name@ref
+* runs the [nested_vms](https://github.com/jpartlow/nested_vms) action
+  to generate a set of test target vms using the
+  [kvm_automation_tooling](https://github.com/jpartlow/kvm_automation_tooling)
+  Bolt module.
+* installs the selected openvox components, either from collections
+  served from the apt and yum voxpupuli repositories, or from the
+  artifacts-url server for pre-release builds.
+* generates a Beaker hosts.yaml from the test target inventory
+* configures and executes Beaker with the given beaker-options,
+  acceptance-pre-suite and acceptance-tests.
+
+#### Usage
+
+Some example usages can be found in the openvox, openvox-agent and
+openvox-server repositories in the `.github/workflows` directory.
+
+See [beaker_acceptance.yml](.github/workflows/beaker_acceptance.yml)
+for parameter details.


### PR DESCRIPTION
This workflow was extracted from the common elements of openvox, openvox-agent and openvox-server .github/workflows/acceptance.{yaml,yml}.

It's intended to replace the guts of each of those and to be useable as a callable acceptance workflow from future workflows for openvoxdb and any other openvox project we need to run beaker on some set of vms for.

Or this could be called within pr testing workflows that first call the build workflows.