### PR TITLE
Drop debian-11 from acceptance os

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -190,11 +190,13 @@ on:
           os-add parameter.
         required: false
         type: string
+        # NOTE: debian-11 has been removed from this list until
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109866 is
+        # resolved and the image is functional again.
         default: |-
           [
             ["almalinux", "8"],
             ["almalinux", "9"],
-            ["debian", "11"],
             ["debian", "12"],
             ["rocky", "8"],
             ["rocky", "9"],


### PR DESCRIPTION
ATM, the archived backports cause a problem in the debian-11 cloud image because the image has not been updated and attempts to source the non-existent backports, causing apt to fail.

If this bug gets resolved, we can readd it, since Debian 11 still has a year on LTS:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109866