### PR TITLE
Do not require fork param in beaker_acceptance.yml

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -15,7 +15,7 @@ on:
       fork:
         description: |-
           The github fork of the project-name Beaker test suite to run.
-        required: true
+        required: false
         type: string
         default: openvoxproject
       install-openvox:


### PR DESCRIPTION
I made a mistake when I added this parameter in that I gave it a default and set required to true. Consequently a calling workflow is forced to set fork even if it would just want the default...

Setting required to false so that callers don't have to pass a fork value unless they want to.