### PR TITLE
Allow CalVer-style version strings

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           ruby-version: '3.3'
           bundler-cache: true
-          working-directory: ${{ inputs.working-directory }}
 
       - name: Add SSH key
         run: |

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository_owner == inputs.allowed_owner
     steps:
-      - name: Make sure inputs.version looks like a valid Semantic Version
+      - name: Make sure inputs.version looks like a valid Semantic Version or Calendar Version
         run: |
-          echo "${{ inputs.version }}" | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)?$'
+          echo "${{ inputs.version }}" | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)?$|^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]$'
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
     if: github.repository_owner == inputs.allowed_owner
     steps:
 
+      - name: Make sure inputs.version looks like a valid Semantic Version or Calendar Version
+        run: |
+          echo "${{ inputs.version }}" | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)?$|^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]$'
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           ruby-version: '3.3'
           bundler-cache: true
-          working-directory: ${{ inputs.working-directory }}
 
       - name: Add SSH key
         run: |


### PR DESCRIPTION
CalVer does not define a single scheme for such versions, but we have
decided to go with a `YYYY.0M.0D.MICRO` format in place of the
`YYYYMMDDX` previously used in some projects like puppet-runtime.
