### PR TITLE
Add Ubuntu 25.04, Debian 13 to ezbake builds and use ezbake-ver

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -20,6 +20,10 @@ on:
           Branch/tag from ezbake that will be used for openvoxdb/server builds.
         type: string
         default: 'main'
+      ezbake-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in the repo if not specified.'
+        type: string
+        required: false
 
 env:
   ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
@@ -29,7 +33,7 @@ env:
   # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
   AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
   AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
-  DEB_PLATFORMS: ${{ inputs.deb_platform_list || 'ubuntu-22.04,ubuntu-24.04,debian-11,debian-12' }}
+  DEB_PLATFORMS: ${{ inputs.deb_platform_list || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,debian-11,debian-12,debian-13' }}
   RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'el-7,el-8,el-9,el-10,sles-15,amazon-2023' }}
   EZBAKE_BRANCH: ${{ inputs.ezbake-ref }}
 
@@ -56,6 +60,10 @@ jobs:
       - name: Update awscli
         run: |
           python -m pip install --upgrade awscli
+
+      - name: Set EZBAKE_VERSION if provided
+        if: ${{ inputs.ezbake-ver != '' }}
+        run: echo "EZBAKE_VERSION=${{ inputs.ezbake-ver }}" >> $GITHUB_ENV
 
       - name: Run build script
         run: |


### PR DESCRIPTION
Ubuntu 25.04 is new and we were missing Debian 13 here. This also wires up the ezbake-ver variable when given. We do it this way because the build rake task looks for the env var to exist to decide if it passes it through to the lein invocation, and we don't want to set it at all if we aren't passing in a value.