### PR TITLE
Changes for MacOS and simpler Linux

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -15,22 +15,20 @@ on:
         description: 'A comma-separated list of platforms to build for. Do not include spaces. If not provided, will use the default list of platforms supported by OpenVox.'
         required: false
         type: string
+      vanagon_branch:
+        description: 'The branch of the vanagon repository to use'
+        required: false
+        type: string
+        default: 'main'
 
 env:
-  ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
-  BUCKET_NAME: ${{ secrets.S3_ARTIFACTS_BUCKET_NAME }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
-  AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
-  AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
+  VANAGON_LOCATION: "https://github.com/openvoxproject/vanagon#${{ inputs.vanagon_branch }}"
 
 jobs:
   set-matrix:
     runs-on: ubuntu-24.04
     outputs:
-      arm_matrix: ${{ steps.set-matrix.outputs.arm_matrix }}
-      x86_matrix: ${{ steps.set-matrix.outputs.x86_matrix }}
+      build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
     steps:
       - id: set-matrix
         run: |
@@ -58,6 +56,8 @@ jobs:
             'fedora-42-aarch64'
             'fedora-43-x86_64'
             'fedora-43-aarch64'
+            'macos-all-arm64'
+            'macos-all-x86_64'
             'sles-15-x86_64'
             'ubuntu-22.04-aarch64'
             'ubuntu-22.04-amd64'
@@ -72,27 +72,32 @@ jobs:
             platforms=("${default_list[@]}")
           fi
 
-          arm_platforms=()
-          x86_platforms=()
+          build_platforms=()
           for platform in "${platforms[@]}"; do
-            if [[ "$platform" == *-aarch64 || "platform" == *-arm64 ]]; then
-              arm_platforms+=("$platform")
+            if [[ "$platform" == macos-* ]]; then
+              runner="macos-latest"
+            elif [[ "$platform" == *-aarch64 || "$platform" == *-arm64 ]]; then
+              runner="ubuntu-24.04-arm"
             else
-              x86_platforms+=("$platform")
+              runner="ubuntu-24.04"
             fi
+            build_platforms+=("{\"platform\":\"$platform\",\"runner\":\"$runner\"}")
           done
-          echo "arm_matrix=$(jq --monochrome-output --compact-output --null-input '$ARGS.positional' --args -- ${arm_platforms[@]})" >> "${GITHUB_OUTPUT}"
-          echo "x86_matrix=$(jq --monochrome-output --compact-output --null-input '$ARGS.positional' --args -- ${x86_platforms[@]})" >> "${GITHUB_OUTPUT}"
+          matrix_json="[$(IFS=','; echo "${build_platforms[*]}")]"
+          echo "build_matrix=$matrix_json" >> "${GITHUB_OUTPUT}"
 
-  build_arm:
+  build:
     needs: set-matrix
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 600
-    if: needs.set-matrix.outputs.arm_matrix != '[""]'
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.set-matrix.outputs.arm_matrix) }}
+        include: ${{ fromJSON(needs.set-matrix.outputs.build_matrix) }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform == 'macos-all-x86_64' && 'arch -x86_64 /bin/bash -e {0}' || 'bash' }}
+
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@v5
@@ -100,61 +105,65 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Install Ruby
+        if: ${{ matrix.platform != 'macos-all-x86_64' }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.7'
+          ruby-version: '3.2'
 
+      - name: Setup brew and Ruby (MacOS x86_64 only)
+        if: ${{ matrix.platform == 'macos-all-x86_64' }}
+        # We must fully uninstall the existing brew install as we need
+        # the x86_64 version, and then we must install Ruby ourselves
+        shell: bash
+        run: |-
+          echo '*** Removing existing homebrew installation ***'
+          brew list --cask | xargs -r brew uninstall --cask --force
+          brew list --formula | xargs -r brew uninstall --force --ignore-dependencies
+          brew autoremove
+          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)" -- --force
+          
+          echo '*** Removing /opt/homebrew directory ***'
+          sudo rm -rf /opt/homebrew
+
+          echo '*** Installing x86_64 homebrew and Ruby ***'
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          arch -x86_64 /bin/bash -c 'brew install ruby@3.2'
+
+          echo '*** Setting up environment variables ***'
+          eval "$(/usr/local/bin/brew shellenv)"
+          echo "HOMEBREW_PREFIX=${HOMEBREW_PREFIX}" >> $GITHUB_ENV
+          echo "HOMEBREW_CELLAR=${HOMEBREW_CELLAR}" >> $GITHUB_ENV
+          echo "HOMEBREW_REPOSITORY=${HOMEBREW_REPOSITORY}" >> $GITHUB_ENV
+          echo "MANPATH=${MANPATH}" >> $GITHUB_ENV
+          echo "INFOPATH=${INFOPATH}" >> $GITHUB_ENV
+          echo "${HOMEBREW_PREFIX}/bin" >> $GITHUB_PATH
+          echo "${HOMEBREW_PREFIX}/sbin" >> $GITHUB_PATH
+          echo '/usr/local/opt/ruby@3.2/bin' >> $GITHUB_PATH
+          echo '/usr/local/lib/ruby/gems/3.2.0/bin' >> $GITHUB_PATH
+          
       - name: Bundle install
         run: bundle install --retry=3
 
-      - name: Update awscli
-        run: python -m pip install --upgrade awscli
-
       - name: Run build script
-        run: |
+        run: |-
           rm -rf output
           bundle exec rake vox:build['${{ inputs.project_name }}','${{ matrix.platform }}']
 
-      - name: Upload output to S3
-        run: bundle exec rake vox:upload['${{ inputs.ref }}','${{ matrix.platform }}']
-  
-  build_x86:
-    needs: set-matrix
-    runs-on: ubuntu-24.04
-    timeout-minutes: 600
-    if: needs.set-matrix.outputs.x86_matrix != '[""]'
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJSON(needs.set-matrix.outputs.x86_matrix) }}
-    steps:
-      - name: Checkout code at tag
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2.7'
-
-      - name: Bundle install
-        run: bundle install --retry=3
-
-      # Re-enable this if we end up needing to build for a platform that
-      # is not x86_64 or arm, e.g. ppc64le.
-      #- name: Install qemu-user-static
-      #  run: |
-      #    sudo apt-get update -y
-      #    sudo apt-get install -y qemu-user-static
-
-      - name: Update awscli
-        run: python -m pip install --upgrade awscli
-
-      - name: Run build script
-        run: |
-          rm -rf output
-          bundle exec rake vox:build['${{ inputs.project_name }}','${{ matrix.platform }}']
+      - name: Install/update awscli
+        run: |-
+          if [[ "${{ matrix.platform }}" == "macos-"* ]]; then
+            brew install --force awscli
+          else
+            python -m pip install --upgrade awscli
+          fi  
 
       - name: Upload output to S3
+        env:
+          ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}
+          BUCKET_NAME: ${{ secrets.S3_ARTIFACTS_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
+          AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
+          AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
         run: bundle exec rake vox:upload['${{ inputs.ref }}','${{ matrix.platform }}']


### PR DESCRIPTION
This adds what we need to be able to run builds with MacOS runners. This also makes the overall flow simpler by containing which runner we should use within the object we get from the set-matrix step itself so we can use a single build job.

Additionally, along with changes to vanagon and build repos, we now build a single binary for all supported MacOS versions, and call the platform string 'macos-all-<arch>'.

Finally, this adds an input to allow overriding the vanagon branch to more easily test changes.