### PR TITLE
Set fetch-depth to 0 to check out all branches and tags

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -165,6 +165,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0 # So we fetch all history and tags and can build non-tagged versions
 
       - name: Install Cygwin and bootstrap dependencies (Windows only)
         if: ${{ startsWith(matrix.platform, 'windows') }}

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -180,15 +180,18 @@ jobs:
       - name: Bundle install
         run: bundle install --retry=3
 
-      - name: Run build script
+      - name: Run build script and save git describe
+        id: build
         run: |-
           rm -rf output
+          DESCRIBE=$(git describe --abbrev=9)
+          echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
           bundle exec rake vox:build['${{ inputs.project_name }}','${{ matrix.platform }}'] 
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.ref }}-${{ matrix.platform }}
+          name: build-artifacts-${{ steps.build.outputs.describe }}-${{ matrix.platform }}
           path: output/
 
       - name: Upload output to S3
@@ -200,4 +203,4 @@ jobs:
           # https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
           AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
           AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
-        run: bundle exec rake vox:upload['${{ inputs.ref }}','${{ matrix.platform }}']
+        run: bundle exec rake vox:upload['${{ steps.build.outputs.describe }}','${{ matrix.platform }}']


### PR DESCRIPTION
The default is fetch depth 1, which checks out just the given commit. Setting this to 0 lets us build against any branch, without having to have tagged it first. Without this, vanagon throws its hands up because it can't get any version from 'git describe'.