### PR TITLE
Add /etc/passwd to Cygwin environment

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -182,7 +182,12 @@ jobs:
           echo "C:\cygwin64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # This is to fix file permissions issues when we check out code outside of Cygwin
           echo "none /cygdrive cygdrive binary,noacl,posix=0,user 0 0" | Out-File -FilePath C:\cygwin64\etc\fstab -Encoding ASCII
-
+          # This is so that Puppet doesn't throw up when we look up Puppet.version in the
+          # openvox repo. It will think it is in a posix environment, but it should not
+          # matter for any other part of the build process.
+          # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
+          echo "root:*:0:0:::" | Out-File -FilePath C:\cygwin64\etc\passwd -Encoding ASCII
+      
       - name: Bundle install
         working-directory: ${{ inputs.working_directory }}
         run: bundle install --retry=3


### PR DESCRIPTION
Because we now use the Puppet library to look up the version, Puppet gets confused when running inside a Cygwin shell. The check for determining if we're in Windows returns false because within the context of Cygwin, it looks like it's not. But the check for a POSIX environment also fails because Cygwin does not provide an /etc/passwd file. This lays down that file so when we load Puppet libraries, it doesn't throw up. It should not affect any other part of the build process.