### PR TITLE
Provide acceptance defaults by project

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -70,7 +70,7 @@ on:
           If true, the openvox-server package will be installed on any
           node in vms with the role 'primary'.
         required: false
-        type: boolean
+        type: string
       openvox-server-version:
         description: |-
           The version of the openvox-server package to install.
@@ -91,7 +91,7 @@ on:
           If true, the openvoxdb package will be installed on any node
           in vms with the role 'primary'.
         required: false
-        type: boolean
+        type: string
       openvoxdb-version:
         description: |-
           The version of the openvoxdb package to install.
@@ -493,7 +493,7 @@ jobs:
           OPENVOX_AGENT_RELEASED: |-
             ${{ !inputs.openvox-agent-pre-release-build }}
           OPENVOX_SERVER_TARGETS: |-
-            ${{ ((needs.set-project-defaults.outputs.install-openvox-server == true) && '"primary"') ||
+            ${{ ((fromJson(needs.set-project-defaults.outputs.install-openvox-server) == true) && '"primary"') ||
                   '[]' }}
           OPENVOX_SERVER_VERSION: |-
             ${{ ((inputs.openvox-server-version == '') && 'latest') ||
@@ -501,7 +501,7 @@ jobs:
           OPENVOX_SERVER_RELEASED: |-
             ${{ !inputs.openvox-server-pre-release-build }}
           OPENVOX_DB_TARGETS: |-
-            ${{ ((needs.set-project-defaults.outputs.install-openvoxdb == true) && '"primary"') ||
+            ${{ ((fromJson(needs.set-project-defaults.outputs.install-openvoxdb) == true) && '"primary"') ||
                  '[]' }}
           OPENVOX_DB_VERSION: |-
             ${{ ((inputs.openvoxdb-version == '') && 'latest') ||

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -18,23 +18,6 @@ on:
         required: false
         type: string
         default: openvoxproject
-      install-openvox:
-        description: |-
-          Whether or not to install any openvox packages on the
-          virtual machines created for the tests.
-
-          If true, then openvox-agent packages will be installed on
-          all nodes listed in the vms input, and openvox-server and
-          openvoxdb packages may be installed depending on the
-          install-openvox-server and install-openvoxdb flags, and on
-          whether the vms input has a node in the 'primary' role.
-
-          If false, then no openvox packages will be installed,
-          regardless of the install-openvox-server or
-          install-openvoxdb flags.
-        required: false
-        type: boolean
-        default: true
       openvox-collection:
         description: |-
           The OpenVox collection to install from.
@@ -65,12 +48,6 @@ on:
         required: false
         type: boolean
         default: true
-      install-openvox-server:
-        description: |-
-          If true, the openvox-server package will be installed on any
-          node in vms with the role 'primary'.
-        required: false
-        type: string
       openvox-server-version:
         description: |-
           The version of the openvox-server package to install.
@@ -86,12 +63,6 @@ on:
         required: false
         type: boolean
         default: true
-      install-openvoxdb:
-        description: |-
-          If true, the openvoxdb package will be installed on any node
-          in vms with the role 'primary'.
-        required: false
-        type: string
       openvoxdb-version:
         description: |-
           The version of the openvoxdb package to install.
@@ -107,15 +78,6 @@ on:
         required: false
         type: boolean
         default: true
-      install-openvoxdb-termini:
-        description: |-
-          In a production installation using openvoxdb, the
-          openvoxdb-termini package is installed alongside
-          openvox-server. Set this to false to install just
-          openvox-server without the openvoxdb-termini.
-        required: false
-        type: boolean
-        default: true
       artifacts-url:
         description: |-
           URL to the artifacts server. This is used to download
@@ -124,97 +86,14 @@ on:
         required: false
         type: string
         default: 'https://s3.osuosl.org/openvox-artifacts'
-      ruby-version:
-        description: |-
-          The Ruby version to use for the project being tested.
-          This is used to install Ruby and run Bundler when
-          running the project's Beaker acceptance suite.
-        required: false
-        type: string
-        default: '3.3'
-      acceptance-working-dir:
-        description: |-
-          The working directory for the acceptance tests, relative to
-          project root.
-        required: false
-        type: string
-      acceptance-pre-suite:
-        description: |-
-          JSON array of Beaker pre-suite files to run.
-          These should be relative to the acceptance-working-dir, or
-          absolute paths.
-          If not provided, no pre-suite will be run.
-        required: false
-        type: string
-      acceptance-tests:
-        description: |-
-          JSON array of Beaker test files to run.
-          These should be relative to the acceptance-working-dir, or
-          absolute paths.
-          If not provided, no tests will be run.
-        required: false
-        type: string
-      beaker-options:
-        description: |-
-          A JSON hash of Beaker options to be included in the
-          .beaker.yml generated for the test suite run.
-
-          This is useful for setting details like 'helper', 'load_path'
-          and 'options_file', among others.
-        required: false
-        type: string
-      os:
-        description: |-
-          JSON array of operating systems to run the tests on.
-          Each entry is an array of minimally [os, os-version],
-          with os-arch and image_version as optional third and fourth
-          elements.
-
-          The elements are passed to jpartlow/nested_vms os,
-          os-version, os-arch and image_version inputs.
-
-          Ex:
-            [
-              ["almalinux", "8"],
-              ["debian", "12", "amd64", "daily-latest"]
-            ]
-
-          Generally the default array can be used, and
-          additional operating systems can be specified with the
-          os-add parameter.
-        required: false
-        type: string
-      os-add:
-        description: |-
-          Additional operating systems to run the tests on.
-          This is a JSON array of the same format as the os input.
-          If provided, these will be added to the end of the os matrix.
-        required: false
-        type: string
-      vms:
-        description: |-
-          JSON array of virtual machine descriptions to create for the
-          tests. This is passed to the jpartlow/nested_vms action and
-          is in a format handled by jpartlow/kvm_automation_tooling's
-          standup_cluster plan.
-
-          Each entry is an object with the following properties:
-          - role: The role of the VM (e.g., "agent").
-          - count: The number of VMs to create for this role.
-          - cpus: The number of CPUs to allocate to each VM.
-          - mem_mb: The amount of memory (in MB) to allocate to each VM.
-          - disk_gb: The amount of disk space (in GB) to allocate to
-            each VM.
-          - cpu_mode: The CPU mode to use for the VM (e.g.,
-            "host-model"). (Necessary for el-9 which expects at least
-            x86_64-2 arch, and depends on the runner's architecture
-            being sufficient.)
-        required: false
-        type: string
 
 env:
   # Suppress warnings about Bolt gem versus package use.
   BOLT_GEM: true
+  # The Ruby version to use for the project being tested.
+  # This is used to install Ruby and run Bundler when
+  # running the project's Beaker acceptance suite.
+  RUBY_VERSION: '3.3'
 
 jobs:
   set-project-defaults:
@@ -233,15 +112,6 @@ jobs:
       - id: set-defaults
         env:
           PROJECT_NAME: ${{ inputs.project-name }}
-          INSTALL_OPENVOX_SERVER: ${{ inputs.install-openvox-server }}
-          INSTALL_OPENVOX_DB: ${{ inputs.install-openvoxdb }}
-          ACCEPTANCE_WORKING_DIR: ${{ inputs.acceptance-working-dir }}
-          ACCEPTANCE_PRE_SUITE: ${{ inputs.acceptance-pre-suite }}
-          ACCEPTANCE_TESTS: ${{ inputs.acceptance-tests }}
-          BEAKER_OPTIONS: ${{ inputs.beaker-options }}
-          OS: ${{ inputs.os }}
-          OS_ADD: ${{ inputs.os-add }}
-          VMS: ${{ inputs.vms }}
           DEFAULT_OS: |-
             [
               ["almalinux", "8"],
@@ -393,11 +263,12 @@ jobs:
               }
             }
         run: |-
+          set -e
+
           # Pick out the defaults for the project being tested.
           jq ".\"${PROJECT_NAME}\" | .os = ${DEFAULT_OS}" <<< "${PROJECT_DEFAULTS}" > project_defaults.json
           cat project_defaults.json
 
-          # Provide project defaults where inputs are not set.
           parameters=(
             "install-openvox-server"
             "install-openvoxdb"
@@ -411,13 +282,9 @@ jobs:
           )
           for param in "${parameters[@]}"; do
             output_name=${param//-/_}
-            env_input_name=${output_name^^}
             default=$(jq -rMc ".\"${param}\"" project_defaults.json)
-            value=${!env_input_name:-$default}
-            # Since the value of env_input_name could be a mutli-line
-            # string from inputs, we'll use jq again to ensure we
-            # produce something output can handle.
-            echo "${output_name}=$(jq -rMc <<<"${value}")" >> $GITHUB_OUTPUT
+            echo "Setting ${output_name} to ${default}"
+            echo "${output_name}=${default}" >> $GITHUB_OUTPUT
           done
 
   set-matrix:
@@ -482,7 +349,6 @@ jobs:
 
       - name: Write Install OpenVox Params
         working-directory: kvm_automation_tooling
-        if: ${{ inputs.install-openvox == true }}
         env:
           OPENVOX_ARTIFACTS_URL: |-
             ${{ inputs.artifacts-url }}
@@ -508,7 +374,7 @@ jobs:
                  inputs.openvoxdb-version }}
           OPENVOX_DB_RELEASED: |-
             ${{ !inputs.openvoxdb-pre-release-build }}
-          INSTALL_TERMINI: ${{ inputs.install-openvoxdb-termini }}
+          INSTALL_TERMINI: true
         run: |-
           cat > install_openvox_params.json <<EOF
           {
@@ -543,7 +409,6 @@ jobs:
 
       - name: Install OpenVox Components
         working-directory: kvm_automation_tooling
-        if: ${{ inputs.install-openvox == true }}
         env:
           # Generated by the nested_vms action.
           INVENTORY: terraform/instances/inventory.test.yaml
@@ -569,7 +434,7 @@ jobs:
       - name: Install Ruby and Run Bundler for Acceptance Tests
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ inputs.ruby-version }}
+          ruby-version: ${{ env.RUBY_VERSION }}
           working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
           bundler-cache: true
 

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -71,7 +71,6 @@ on:
           node in vms with the role 'primary'.
         required: false
         type: boolean
-        default: true
       openvox-server-version:
         description: |-
           The version of the openvox-server package to install.
@@ -93,7 +92,6 @@ on:
           in vms with the role 'primary'.
         required: false
         type: boolean
-        default: false
       openvoxdb-version:
         description: |-
           The version of the openvoxdb package to install.
@@ -140,7 +138,6 @@ on:
           project root.
         required: false
         type: string
-        default: 'acceptance'
       acceptance-pre-suite:
         description: |-
           JSON array of Beaker pre-suite files to run.
@@ -149,7 +146,6 @@ on:
           If not provided, no pre-suite will be run.
         required: false
         type: string
-        default: '[]'
       acceptance-tests:
         description: |-
           JSON array of Beaker test files to run.
@@ -158,7 +154,6 @@ on:
           If not provided, no tests will be run.
         required: false
         type: string
-        default: '[]'
       beaker-options:
         description: |-
           A JSON hash of Beaker options to be included in the
@@ -168,7 +163,6 @@ on:
           and 'options_file', among others.
         required: false
         type: string
-        default: '{}'
       os:
         description: |-
           JSON array of operating systems to run the tests on.
@@ -190,17 +184,6 @@ on:
           os-add parameter.
         required: false
         type: string
-        default: |-
-          [
-            ["almalinux", "8"],
-            ["almalinux", "9"],
-            ["debian", "11"],
-            ["debian", "12"],
-            ["rocky", "8"],
-            ["rocky", "9"],
-            ["ubuntu", "22.04"],
-            ["ubuntu", "24.04"]
-          ]
       os-add:
         description: |-
           Additional operating systems to run the tests on.
@@ -208,7 +191,6 @@ on:
           If provided, these will be added to the end of the os matrix.
         required: false
         type: string
-        default: '[]'
       vms:
         description: |-
           JSON array of virtual machine descriptions to create for the
@@ -229,31 +211,225 @@ on:
             being sufficient.)
         required: false
         type: string
-        default: |-
-          [
-            {
-              "role": "agent",
-              "count": 1,
-              "cpus": 2,
-              "mem_mb": 4096,
-              "cpu_mode": "host-model"
-            }
-          ]
 
 env:
   # Suppress warnings about Bolt gem versus package use.
   BOLT_GEM: true
 
 jobs:
+  set-project-defaults:
+    runs-on: ubuntu-24.04
+    outputs:
+      install-openvox-server: ${{ steps.set-defaults.outputs.install_openvox_server }}
+      install-openvoxdb: ${{ steps.set-defaults.outputs.install_openvoxdb }}
+      acceptance-working-dir: ${{ steps.set-defaults.outputs.acceptance_working_dir }}
+      acceptance-pre-suite: ${{ steps.set-defaults.outputs.acceptance_pre_suite }}
+      acceptance-tests: ${{ steps.set-defaults.outputs.acceptance_tests }}
+      beaker-options: ${{ steps.set-defaults.outputs.beaker_options }}
+      os: ${{ steps.set-defaults.outputs.os }}
+      os-add: ${{ steps.set-defaults.outputs.os_add }}
+      vms: ${{ steps.set-defaults.outputs.vms }}
+    steps:
+      - id: set-defaults
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+          INSTALL_OPENVOX_SERVER: ${{ inputs.install-openvox-server }}
+          INSTALL_OPENVOX_DB: ${{ inputs.install-openvoxdb }}
+          ACCEPTANCE_WORKING_DIR: ${{ inputs.acceptance-working-dir }}
+          ACCEPTANCE_PRE_SUITE: ${{ inputs.acceptance-pre-suite }}
+          ACCEPTANCE_TESTS: ${{ inputs.acceptance-tests }}
+          BEAKER_OPTIONS: ${{ inputs.beaker-options }}
+          OS: ${{ inputs.os }}
+          OS_ADD: ${{ inputs.os-add }}
+          VMS: ${{ inputs.vms }}
+          DEFAULT_OS: |-
+            [
+              ["almalinux", "8"],
+              ["almalinux", "9"],
+              ["debian", "11"],
+              ["debian", "12"],
+              ["rocky", "8"],
+              ["rocky", "9"],
+              ["ubuntu", "22.04"],
+              ["ubuntu", "24.04"]
+            ]
+          PROJECT_DEFAULTS: |-
+            {
+              "openvox": {
+                "install-openvox-server": true,
+                "install-openvoxdb": false,
+                "acceptance-working-dir": "acceptance",
+                "acceptance-pre-suite": [
+                  "pre-suite"
+                ],
+                "acceptance-tests": [
+                  "tests"
+                ],
+                "beaker-options": {
+                  "helper":       "lib/helper.rb",
+                  "options_file": "config/aio/options.rb"
+                },
+                "os-add": [],
+                "vms": [
+                  {
+                    "role": "primary",
+                    "count": 1,
+                    "cpus": 4,
+                    "mem_mb": 8192,
+                    "cpu_mode": "host-model"
+                  }
+                ]
+              },
+              "openvox-agent": {
+                "install-openvox-server": false,
+                "install-openvoxdb": false,
+                "acceptance-working-dir": "acceptance",
+                "acceptance-pre-suite": [
+                  "pre-suite/configure_type_defaults.rb"
+                ],
+                "acceptance-tests": [
+                  "tests"
+                ],
+                "beaker-options": {
+                  "helper":       "lib/helper.rb"
+                },
+                "os-add": [
+                  ["debian", "13", "amd64", "daily-latest"]
+                ],
+                "vms": [
+                  {
+                    "role": "agent",
+                    "count": 1,
+                    "cpus": 2,
+                    "mem_mb": 4096,
+                    "cpu_mode": "host-model"
+                  }
+                ]
+              },
+              "openvox-server": {
+                "install-openvox-server": true,
+                "install-openvoxdb": true,
+                "acceptance-working-dir": "./",
+                "acceptance-pre-suite": [
+                  "acceptance/suites/pre_suite/openvox/configure_type_defaults.rb",
+                  "acceptance/suites/pre_suite/foss/00_setup_environment.rb",
+                  "acceptance/suites/pre_suite/foss/070_InstallCACerts.rb",
+                  "acceptance/suites/pre_suite/foss/10_update_ca_certs.rb",
+                  "acceptance/suites/pre_suite/foss/15_prep_locales.rb",
+                  "acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb",
+                  "acceptance/suites/pre_suite/foss/80_configure_puppet.rb",
+                  "acceptance/suites/pre_suite/foss/85_configure_sut.rb",
+                  "acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb",
+                  "acceptance/suites/pre_suite/foss/95_install_pdb.rb",
+                  "acceptance/suites/pre_suite/foss/99_collect_data.rb"
+                ],
+                "acceptance-tests": [
+                  "acceptance/suites/tests"
+                ],
+                "beaker-options": {
+                  "helper":       "acceptance/lib/helper.rb",
+                  "load_path":    "acceptance/lib",
+                  "options_file": "acceptance/config/beaker/options.rb"
+                },
+                "os-add": [],
+                "vms": [
+                  {
+                    "role": "primary",
+                    "count": 1,
+                    "cpus": 4,
+                    "mem_mb": 8192,
+                    "cpu_mode": "host-model"
+                  },
+                  {
+                    "role": "agent",
+                    "count": 1,
+                    "cpus": 2,
+                    "mem_mb": 2048,
+                    "cpu_mode": "host-model"
+                  }
+                ]
+              },
+              "openvoxdb": {
+                "install-openvox-server": true,
+                "install-openvoxdb": true,
+                "acceptance-working-dir": "./",
+                "acceptance-pre-suite": [
+                  "acceptance/setup/openvox/configure_type_defaults.rb",
+                  "acceptance/setup/pre_suite/00_setup_test_env.rb",
+                  "acceptance/setup/pre_suite/10_setup_proxies.rb",
+                  "acceptance/setup/pre_suite/15_prep_locales.rb",
+                  "acceptance/setup/pre_suite/20_install_puppet.rb",
+                  "acceptance/setup/pre_suite/30_generate_ssl_certs.rb",
+                  "acceptance/setup/pre_suite/40_install_deps.rb",
+                  "acceptance/setup/pre_suite/50_install_modules.rb",
+                  "acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb",
+                  "acceptance/setup/pre_suite/80_add_dev_repo.rb",
+                  "acceptance/setup/openvox/configure_openvoxdb.rb"
+                ],
+                "acceptance-tests": [
+                  "acceptance/tests"
+                ],
+                "beaker-options": {
+                  "helper":       "acceptance/helper.rb",
+                  "options_file": "acceptance/options/openvox.rb"
+                },
+                "os-add": [],
+                "vms": [
+                  {
+                    "role": "primary",
+                    "count": 1,
+                    "cpus": 4,
+                    "mem_mb": 8192,
+                    "cpu_mode": "host-model"
+                  },
+                  {
+                    "role": "agent",
+                    "count": 1,
+                    "cpus": 2,
+                    "mem_mb": 2048,
+                    "cpu_mode": "host-model"
+                  }
+                ]
+              }
+            }
+        run: |-
+          # Pick out the defaults for the project being tested.
+          jq ".\"${PROJECT_NAME}\" | .os = ${DEFAULT_OS}" <<< "${PROJECT_DEFAULTS}" > project_defaults.json
+          cat project_defaults.json
+
+          # Provide project defaults where inputs are not set.
+          parameters=(
+            "install-openvox-server"
+            "install-openvoxdb"
+            "acceptance-working-dir"
+            "acceptance-pre-suite"
+            "acceptance-tests"
+            "beaker-options"
+            "os"
+            "os-add"
+            "vms"
+          )
+          for param in "${parameters[@]}"; do
+            output_name=${param//-/_}
+            env_input_name=${output_name^^}
+            default=$(jq -rMc ".\"${param}\"" project_defaults.json)
+            value=${!env_input_name:-$default}
+            # Since the value of env_input_name could be a mutli-line
+            # string from inputs, we'll use jq again to ensure we
+            # produce something output can handle.
+            echo "${output_name}=$(jq -rMc <<<"${value}")" >> $GITHUB_OUTPUT
+          done
+
   set-matrix:
+    needs: set-project-defaults
     runs-on: ubuntu-24.04
     outputs:
       os-matrix: ${{ steps.set-matrix.outputs.os_matrix }}
     steps:
       - id: set-matrix
         env:
-          OS: ${{ inputs.os }}
-          OS_ADD: ${{ inputs.os-add }}
+          OS: ${{ needs.set-project-defaults.outputs.os }}
+          OS_ADD: ${{ needs.set-project-defaults.outputs.os-add }}
         run: |-
           cat > matrix_inputs.json <<EOF
           [
@@ -266,7 +442,7 @@ jobs:
 
   acceptance:
     name: Acceptance Tests
-    needs: set-matrix
+    needs: [set-project-defaults, set-matrix]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -277,7 +453,7 @@ jobs:
         ${{ format('{0}/{1}/{2}',
                    github.workspace,
                    inputs.project-name,
-                   inputs.acceptance-working-dir) }}
+                   needs.set-project-defaults.outputs.acceptance-working-dir) }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -302,7 +478,7 @@ jobs:
           # the runner's architecture being sufficient, and there is
           # probably a better way to get this set on the libvirt
           # domain instead.
-          vms: ${{ inputs.vms }}
+          vms: ${{ needs.set-project-defaults.outputs.vms }}
 
       - name: Write Install OpenVox Params
         working-directory: kvm_automation_tooling
@@ -317,7 +493,7 @@ jobs:
           OPENVOX_AGENT_RELEASED: |-
             ${{ !inputs.openvox-agent-pre-release-build }}
           OPENVOX_SERVER_TARGETS: |-
-            ${{ ((inputs.install-openvox-server == true) && '"primary"') ||
+            ${{ ((needs.set-project-defaults.outputs.install-openvox-server == true) && '"primary"') ||
                   '[]' }}
           OPENVOX_SERVER_VERSION: |-
             ${{ ((inputs.openvox-server-version == '') && 'latest') ||
@@ -325,7 +501,7 @@ jobs:
           OPENVOX_SERVER_RELEASED: |-
             ${{ !inputs.openvox-server-pre-release-build }}
           OPENVOX_DB_TARGETS: |-
-            ${{ ((inputs.install-openvoxdb == true) && '"primary"') ||
+            ${{ ((needs.set-project-defaults.outputs.install-openvoxdb == true) && '"primary"') ||
                  '[]' }}
           OPENVOX_DB_VERSION: |-
             ${{ ((inputs.openvoxdb-version == '') && 'latest') ||
@@ -405,11 +581,11 @@ jobs:
           # Generated by the nested_vms action.
           SSH_KEY: ~/.ssh/ssh-id-test
           PRE_SUITE_ARRAY: |-
-            ${{ inputs.acceptance-pre-suite || '[]' }}
+            ${{ needs.set-project-defaults.outputs.acceptance-pre-suite || '[]' }}
           TESTS_ARRAY: |-
-            ${{ inputs.acceptance-tests || '[]' }}
+            ${{ needs.set-project-defaults.outputs.acceptance-tests || '[]' }}
           BEAKER_OPTIONS: |-
-            ${{ inputs.beaker-options || '{}' }}
+            ${{ needs.set-project-defaults.outputs.beaker-options || '{}' }}
         run: |-
           cat > beaker.yml.inputs <<EOF
           [

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -3,18 +3,18 @@ name: Run Beaker acceptance tests on an OpenVox project
 on:
   workflow_call:
     inputs:
-      project-name:
-        description: The OpenVox project to test.
+      suite-name:
+        description: The identifier of the Beaker test suite to run.
         required: true
         type: string
       ref:
         description: |-
-          The git ref of the project-name Beaker test suite to run.
+          The git ref of the suite-name repository to checkout and run.
         required: true
         type: string
       fork:
         description: |-
-          The github fork of the project-name Beaker test suite to run.
+          The github fork of the suite-name repository to checkout and run.
         required: false
         type: string
         default: openvoxproject
@@ -99,6 +99,7 @@ jobs:
   set-project-defaults:
     runs-on: ubuntu-24.04
     outputs:
+      repository: ${{ steps.set-defaults.outputs.repository }}
       install-openvox-server: ${{ steps.set-defaults.outputs.install_openvox_server }}
       install-openvoxdb: ${{ steps.set-defaults.outputs.install_openvoxdb }}
       acceptance-working-dir: ${{ steps.set-defaults.outputs.acceptance_working_dir }}
@@ -111,7 +112,7 @@ jobs:
     steps:
       - id: set-defaults
         env:
-          PROJECT_NAME: ${{ inputs.project-name }}
+          SUITE_NAME: ${{ inputs.suite-name }}
           DEFAULT_OS: |-
             [
               ["almalinux", "8"],
@@ -126,6 +127,7 @@ jobs:
           PROJECT_DEFAULTS: |-
             {
               "openvox": {
+                "repository": "openvox",
                 "install-openvox-server": true,
                 "install-openvoxdb": false,
                 "acceptance-working-dir": "acceptance",
@@ -151,9 +153,10 @@ jobs:
                 ]
               },
               "openvox-agent": {
+                "repository": "openvox",
                 "install-openvox-server": false,
                 "install-openvoxdb": false,
-                "acceptance-working-dir": "acceptance",
+                "acceptance-working-dir": "packaging/acceptance",
                 "acceptance-pre-suite": [
                   "pre-suite/configure_type_defaults.rb"
                 ],
@@ -177,6 +180,7 @@ jobs:
                 ]
               },
               "openvox-server": {
+                "repository": "openvox-server",
                 "install-openvox-server": true,
                 "install-openvoxdb": true,
                 "acceptance-working-dir": "./",
@@ -220,6 +224,7 @@ jobs:
                 ]
               },
               "openvoxdb": {
+                "repository": "openvoxdb",
                 "install-openvox-server": true,
                 "install-openvoxdb": true,
                 "acceptance-working-dir": "./",
@@ -266,10 +271,11 @@ jobs:
           set -e
 
           # Pick out the defaults for the project being tested.
-          jq ".\"${PROJECT_NAME}\" | .os = ${DEFAULT_OS}" <<< "${PROJECT_DEFAULTS}" > project_defaults.json
+          jq ".\"${SUITE_NAME}\" | .os = ${DEFAULT_OS}" <<< "${PROJECT_DEFAULTS}" > project_defaults.json
           cat project_defaults.json
 
           parameters=(
+            "repository"
             "install-openvox-server"
             "install-openvoxdb"
             "acceptance-working-dir"
@@ -319,7 +325,7 @@ jobs:
       ACCEPTANCE_WORKING_DIR: |-
         ${{ format('{0}/{1}/{2}',
                    github.workspace,
-                   inputs.project-name,
+                   needs.set-project-defaults.outputs.repository,
                    needs.set-project-defaults.outputs.acceptance-working-dir) }}
     steps:
       - uses: actions/checkout@v5
@@ -327,9 +333,9 @@ jobs:
           # Ensure that we checkout the project we want to test rather
           # than the repository that this workflow is being called
           # from.
-          repository: ${{ format('{0}/{1}', inputs.fork, inputs.project-name) }}
+          repository: ${{ format('{0}/{1}', inputs.fork, needs.set-project-defaults.outputs.repository) }}
           ref: ${{ inputs.ref }}
-          path: ${{ inputs.project-name }}
+          path: ${{ needs.set-project-defaults.outputs.repository }}
 
       - id: vm-cluster
         uses: jpartlow/nested_vms@v1


### PR DESCRIPTION
Sane defaults for beaker options, os matrices and vms definitions are
currently duplicated in the various
project/.github/workflows/acceptance.yml workflows, and in the
openvoxproject/acceptance-pipelines/.github/workflows/openvox_acceptance_pipeline.yml,
and would be duplicated again as I work out a build_and_test.yml
pipeline that would also call into beaker_acceptance.yml

This patch pulls all of these fairly static defaults into
beaker_acceptance.yml and selects the correct set based on the give
project-name. This way the callers can just provide the project-name,
ref, and key inputs like versions, unless they really need to fiddle
with beaker for their particular run.

---

The project-name input used to be synonymous with the actual repository
containing the test suite to execute. But since the separate
openvox-agent repository was deprecated and pushed into
openvox/packaging, that no longer applies, and we have two test suites
inside the openvox repository, openvox/acceptance (the openvox test
suite) and openvox/packaging/acceptance (the openvox-agent test suite)
that we need to be able to execute.

This commit changes project-name to suite-name, and tracks the actual
repository as a default selected with the rest of the defaults
associated with suite-name.