### PR TITLE
Install openvoxdb-termini for acceptance based on suite

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -130,6 +130,7 @@ jobs:
                 "repository": "openvox",
                 "install-openvox-server": true,
                 "install-openvoxdb": false,
+                "install-termini": false,
                 "acceptance-working-dir": "acceptance",
                 "acceptance-pre-suite": [
                   "pre-suite"
@@ -156,6 +157,7 @@ jobs:
                 "repository": "openvox",
                 "install-openvox-server": false,
                 "install-openvoxdb": false,
+                "install-termini": false,
                 "acceptance-working-dir": "packaging/acceptance",
                 "acceptance-pre-suite": [
                   "pre-suite/configure_type_defaults.rb"
@@ -183,6 +185,7 @@ jobs:
                 "repository": "openvox-server",
                 "install-openvox-server": true,
                 "install-openvoxdb": true,
+                "install-termini": true,
                 "acceptance-working-dir": "./",
                 "acceptance-pre-suite": [
                   "acceptance/suites/pre_suite/openvox/configure_type_defaults.rb",
@@ -227,6 +230,7 @@ jobs:
                 "repository": "openvoxdb",
                 "install-openvox-server": true,
                 "install-openvoxdb": true,
+                "install-termini": true,
                 "acceptance-working-dir": "./",
                 "acceptance-pre-suite": [
                   "acceptance/setup/openvox/configure_type_defaults.rb",
@@ -278,6 +282,7 @@ jobs:
             "repository"
             "install-openvox-server"
             "install-openvoxdb"
+            "install-termini"
             "acceptance-working-dir"
             "acceptance-pre-suite"
             "acceptance-tests"
@@ -380,7 +385,8 @@ jobs:
                  inputs.openvoxdb-version }}
           OPENVOX_DB_RELEASED: |-
             ${{ !inputs.openvoxdb-pre-release-build }}
-          INSTALL_TERMINI: true
+          INSTALL_TERMINI: |-
+            ${{ needs.set-project-defaults.outputs.install-termini }}
         run: |-
           cat > install_openvox_params.json <<EOF
           {


### PR DESCRIPTION
The acceptance-pipelines workflow sets openvoxdb vars because it runs all the suites, so the openvox suite, which installs openvox-server, was able to install openvoxdb-termini because the openvoxdb versions vars happened to be set. But the openvoxproject/openvox acceptance pipeline was failing to install openvoxdb-termini because it only gets openvox and openvox-server version vars from its inputs.

This change determines whether to install the openvoxdb termini based on the suite being run. Only the openvox-server and openvoxdb defaults have install-termini true now.