### PR TITLE
Export the install-termini value in beaker_acceptance.yml

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -102,6 +102,7 @@ jobs:
       repository: ${{ steps.set-defaults.outputs.repository }}
       install-openvox-server: ${{ steps.set-defaults.outputs.install_openvox_server }}
       install-openvoxdb: ${{ steps.set-defaults.outputs.install_openvoxdb }}
+      install-termini: ${{ steps.set-defaults.outputs.install_termini }}
       acceptance-working-dir: ${{ steps.set-defaults.outputs.acceptance_working_dir }}
       acceptance-pre-suite: ${{ steps.set-defaults.outputs.acceptance_pre_suite }}
       acceptance-tests: ${{ steps.set-defaults.outputs.acceptance_tests }}


### PR DESCRIPTION
This was coming up blank.

I'm not 100% certain this is the correct fix, so I'm going to put up a branch to run openvox acceptance with this branches change. :/

Yep, that was not correct; I forgot to actually put install-termini in the outputs.

Let's see if this does it.