### PR TITLE
Add switch for uploading to S3

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: '.'
+      upload_to_s3:
+        description: 'Whether to upload the built artifacts to S3. If false, the artifacts will only be uploaded as workflow artifacts.'
+        required: false
+        type: boolean
+        default: true
 
 env:
   VANAGON_LOCATION: "https://github.com/openvoxproject/vanagon#${{ inputs.vanagon_branch }}"
@@ -208,6 +213,7 @@ jobs:
           path: ${{ inputs.working_directory }}/output/
 
       - name: Upload output to S3
+        if: ${{ inputs.upload_to_s3 }}
         working-directory: ${{ inputs.working_directory }}
         env:
           ENDPOINT_URL: ${{ secrets.S3_ENDPOINT_URL }}


### PR DESCRIPTION
When we're just testing things, we often don't need to upload things to S3 and can just download the artifacts directly from the job. This lets us disable uploading to S3 so we don't fill it with too much garbage.