### PR TITLE
Use arm64 host to cross compile macos-all-x86_64

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -86,11 +86,7 @@ jobs:
           build_platforms=()
           for platform in "${platforms[@]}"; do
             case "$platform" in
-              macos-*-x86_64)
-                runner="macos-latest"
-                shell="arch -x86_64 /bin/bash -e {0}"
-                ;;
-              macos-*-arm64)
+              macos-*)
                 runner="macos-latest"
                 shell="bash"
                 ;;
@@ -126,42 +122,16 @@ jobs:
         shell: ${{ matrix.shell }}
 
     steps:
-      - name: Install Ruby (except Windows and macos-all-x86_64)
-        if: ${{ matrix.platform != 'macos-all-x86_64' && ! startsWith(matrix.platform, 'windows') }}
+      - name: Install Ruby (except Windows)
+        id: install-ruby
+        if: ${{ ! startsWith(matrix.platform, 'windows') }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
 
-      - name: Setup brew and Ruby (MacOS x86_64 only)
-        if: ${{ matrix.platform == 'macos-all-x86_64' }}
-        # We must fully uninstall the existing brew install as we need
-        # the x86_64 version, and then we must install Ruby ourselves
-        shell: bash
-        run: |-
-          echo '*** Removing existing homebrew installation ***'
-          brew list --cask | xargs -r brew uninstall --cask --force
-          brew list --formula | xargs -r brew uninstall --force --ignore-dependencies
-          brew autoremove
-          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)" -- --force
-          
-          echo '*** Removing /opt/homebrew directory ***'
-          sudo rm -rf /opt/homebrew
-
-          echo '*** Installing x86_64 homebrew and Ruby ***'
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          arch -x86_64 /bin/bash -c 'brew install ruby@3.2'
-
-          echo '*** Setting up environment variables ***'
-          eval "$(/usr/local/bin/brew shellenv)"
-          echo "HOMEBREW_PREFIX=${HOMEBREW_PREFIX}" >> $GITHUB_ENV
-          echo "HOMEBREW_CELLAR=${HOMEBREW_CELLAR}" >> $GITHUB_ENV
-          echo "HOMEBREW_REPOSITORY=${HOMEBREW_REPOSITORY}" >> $GITHUB_ENV
-          echo "MANPATH=${MANPATH}" >> $GITHUB_ENV
-          echo "INFOPATH=${INFOPATH}" >> $GITHUB_ENV
-          echo "${HOMEBREW_PREFIX}/bin" >> $GITHUB_PATH
-          echo "${HOMEBREW_PREFIX}/sbin" >> $GITHUB_PATH
-          echo '/usr/local/opt/ruby@3.2/bin' >> $GITHUB_PATH
-          echo '/usr/local/lib/ruby/gems/3.2.0/bin' >> $GITHUB_PATH
+      - name: Save Ruby prefix (except Windows)
+        if: ${{ ! startsWith(matrix.platform, 'windows') }}
+        run: echo "HOST_RUBY_PREFIX=${{ steps.install-ruby.outputs.ruby-prefix }}" >> $GITHUB_ENV
 
       - name: Set git params for Windows
         if: ${{ startsWith(matrix.platform, 'windows') }}


### PR DESCRIPTION
Now that we have cross-compilation working in order to build the x86_64 MacOS client, remove all of the stuff we were trying to do to compile it via Rosetta.