### PR TITLE
Add redhatfips 8 and 9 to default build platforms

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -66,6 +66,8 @@ jobs:
             'fedora-43-aarch64'
             'macos-all-arm64'
             'macos-all-x86_64'
+            'redhatfips-8-x86_64'
+            'redhatfips-9-x86_64'
             'sles-15-x86_64'
             'sles-16-aarch64'
             'sles-16-x86_64'


### PR DESCRIPTION
After doing some research, I'm fairly confident we should be able to build the redhatfips artifacts on a non-FIPS enabled host. There should be no hidden checks of the fips_enabled file inside the individual components we are building.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
