### PR TITLE
Update bundle install command to exclude 'release' group

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Bundle install
         working-directory: ${{ inputs.working_directory }}
-        run: bundle install --retry=3
+        run: bundle config set without 'release' && bundle install --retry=3
 
       # from https://github.com/Sharpie/puppet-build-experiment/blob/master/resources/bolt/tasks/configure_builder.sh#L3-L14
       - name: Force docker into 32bit mode


### PR DESCRIPTION
We don't need the release gems when doing a build, and github_changelog_generator with faraday doesn't install quite right on MacOS x86_64.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
