### PR TITLE
Use bundler 2.7.2 for macox-all-x86_64

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -169,6 +169,10 @@ jobs:
           echo "${HOMEBREW_PREFIX}/sbin" >> $GITHUB_PATH
           echo '/usr/local/opt/ruby@3.2/bin' >> $GITHUB_PATH
           echo '/usr/local/lib/ruby/gems/3.2.0/bin' >> $GITHUB_PATH
+          
+          echo '*** Using 2.x version of bundler for now ***'
+          arch -x86_64 /usr/local/opt/ruby@3.2/bin/gem install bundler -v 2.7.2
+          echo "BUNDLER_VERSION=2.7.2" >> $GITHUB_ENV
 
       - name: Set git params for Windows
         if: ${{ startsWith(matrix.platform, 'windows') }}


### PR DESCRIPTION
When we install ruby@3.2 with homebrew, it does "gem install bundler", which picks up bundler 4.x. That isn't particularly stable right now and ends up causing problems with dependency resolution. This pins us to bundler 2.7.2 for the time being.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
