### PR TITLE
Macos 26

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -94,11 +94,11 @@ jobs:
           for platform in "${platforms[@]}"; do
             case "$platform" in
               macos-*-x86_64)
-                runner="macos-latest"
+                runner="macos-26"
                 shell="arch -x86_64 /bin/bash -e {0}"
                 ;;
               macos-*-arm64)
-                runner="macos-latest"
+                runner="macos-26"
                 shell="bash"
                 ;;
               windows-*)


### PR DESCRIPTION
This moves MacOS builds to the macos-26 runner, since macos-latest is still 15.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
