### PR TITLE
Skip redhatfips platforms for openbolt

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -88,6 +88,10 @@ jobs:
             IFS=',' read -r -a platforms <<< "${{ inputs.platform_list }}"
           else
             platforms=("${default_list[@]}")
+            # openbolt does not support redhatfips
+            if [[ "${{ inputs.project_name }}" == "openbolt" ]]; then
+              mapfile -t platforms < <(printf '%s\n' "${platforms[@]}" | grep -v '^redhatfips-')
+            fi
           fi
 
           build_platforms=()


### PR DESCRIPTION
We don't yet support redhatfips for OpenBolt. Until we do, filter them out of the default platform list.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
