### PR TITLE
Add el-7-x86_64 back into OpenVox 8 builds

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -34,7 +34,7 @@ env:
   AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
   AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
   DEB_PLATFORMS: ${{ inputs.deb_platform_list || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-26.04,debian-11,debian-12,debian-13' }}
-  RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'amazon-2,amazon-2023,el-8,el-9,el-10,fedora-42,fedora-43,sles-15,sles-16' }}
+  RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'amazon-2,amazon-2023,el-7,el-8,el-9,el-10,fedora-42,fedora-43,sles-15,sles-16' }}
   EZBAKE_BRANCH: ${{ inputs.ezbake-ref }}
 
 jobs:

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -54,6 +54,7 @@ jobs:
             'debian-13-aarch64'
             'debian-13-amd64'
             'debian-13-armhf'
+            'el-7-x86_64'
             'el-8-aarch64'
             'el-8-x86_64'
             'el-9-aarch64'


### PR DESCRIPTION
We've decide we're going to build for el7 again for OpenVox 8, since this is a particularly special long-lived platform that people are still in the process of migrating off of. We'll remove support for it again in OpenVox 9.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
