### PR TITLE
Drop EL7 ezbake builds

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -34,7 +34,7 @@ env:
   AWS_REQUEST_CHECKSUM_CALCULATION: "WHEN_REQUIRED"
   AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
   DEB_PLATFORMS: ${{ inputs.deb_platform_list || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-26.04,debian-11,debian-12,debian-13' }}
-  RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'amazon-2,amazon-2023,el-7,el-8,el-9,el-10,fedora-42,fedora-43,sles-15,sles-16' }}
+  RPM_PLATFORMS: ${{ inputs.rpm_platform_list || 'amazon-2,amazon-2023,el-8,el-9,el-10,fedora-42,fedora-43,sles-15,sles-16' }}
   EZBAKE_BRANCH: ${{ inputs.ezbake-ref }}
 
 jobs:


### PR DESCRIPTION
Partial revert of b9fd7c42a09c566515bf254afcaea47613b7420c

CentOS 7  / OracleLinux 7 only ship Java 8 & 11. We require Java 17. So we cannot build that (easily) at the moment

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
