### PR TITLE
Update platform filtering for openbolt

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -89,9 +89,9 @@ jobs:
             IFS=',' read -r -a platforms <<< "${{ inputs.platform_list }}"
           else
             platforms=("${default_list[@]}")
-            # openbolt does not support redhatfips
-            if [[ "${{ inputs.project_name }}" == "openbolt" ]]; then
-              mapfile -t platforms < <(printf '%s\n' "${platforms[@]}" | grep -v '^redhatfips-')
+            # openbolt and openbolt-runtime do not support redhatfips or el-7
+            if [[ "${{ inputs.project_name }}" == openbolt* ]]; then
+              mapfile -t platforms < <(printf '%s\n' "${platforms[@]}" | grep -v -e '^redhatfips-' -e '^el-7-')
             fi
           fi
 


### PR DESCRIPTION
We need to filter out both redhatfips and el7 from openbolt-runtime and openbolt builds.

openbolt-runtime builds for redhatfips, but the result isn't FIPS compliant and updates are needed to make it so.

openbolt-runtime will not build for el7 because we don't build curl and system libcurl is too old. If we need to fix this later, we can, but for now, just disable it.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
