### PR TITLE
Use Ruby 4 for builder image and cache it

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -75,8 +75,29 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.9'
+          ruby-version: '4.0'
           bundler-cache: true
+
+      - id: docker-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
+
+      - name: Load or build Docker image
+        run: |
+          if [[ -f /tmp/ezbake-builder.tar ]]; then
+            docker load -i /tmp/ezbake-builder.tar
+          else
+            docker build -t ezbake-builder .
+            docker save ezbake-builder -o /tmp/ezbake-builder.tar
+          fi
+
+      - uses: actions/cache/save@v4
+        if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
 
       - name: Update awscli
         run: |

--- a/.github/workflows/build_ezbake_fips.yml
+++ b/.github/workflows/build_ezbake_fips.yml
@@ -70,8 +70,29 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.9'
+          ruby-version: '4.0'
           bundler-cache: true
+
+      - id: docker-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
+
+      - name: Load or build Docker image
+        run: |
+          if [[ -f /tmp/ezbake-builder.tar ]]; then
+            docker load -i /tmp/ezbake-builder.tar
+          else
+            docker build -t ezbake-builder .
+            docker save ezbake-builder -o /tmp/ezbake-builder.tar
+          fi
+
+      - uses: actions/cache/save@v4
+        if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
 
       - name: Update awscli
         run: |


### PR DESCRIPTION
Rather than recreate the builder container every time using rbenv, which takes quite a while, this uses the off-the-shell Ruby 4 Bookworm image. It also caches the image in GitHub for the PR job that tests the build.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
