### PR TITLE
Add Fedora 44 to Vanagon builds

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -16,6 +16,8 @@
       "el-10-aarch64",
       "fedora-43-x86_64",
       "fedora-43-aarch64",
+      "fedora-44-x86_64",
+      "fedora-44-aarch64",
       "macos-all-arm64",
       "macos-all-x86_64",
       "redhatfips-8-x86_64",

--- a/platforms.json
+++ b/platforms.json
@@ -80,6 +80,8 @@
       "fedora-42-aarch64",
       "fedora-43-x86_64",
       "fedora-43-aarch64",
+      "fedora-44-x86_64",
+      "fedora-44-aarch64",
       "macos-all-arm64",
       "macos-all-x86_64",
       "redhatfips-8-x86_64",


### PR DESCRIPTION
### Short description

This changeset adds Fedora 44 to the build matrices for the `8.x` and `main` branches.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
