### PR TITLE
Add MSYS2 vanagon build

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -182,6 +182,9 @@ jobs:
 
       - name: Configure MSYS2 (Windows only)
         if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
+        env:
+          # Disable MSYS2 PATH stripping so that winget CLI is visible.
+          MSYS2_PATH_TYPE: inherit
         run: |
           # bundle install hangs under MSYS2 Ruby when more than one
           # job is run in parallel.
@@ -192,6 +195,15 @@ jobs:
           # matter for any other part of the build process.
           # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
           echo "root:*:0:0:::" >>/etc/passwd
+
+          # WinGet exits with a failure code if asked to install an
+          # already-installed package.
+          winget list \
+            --accept-source-agreements \
+            --id WiXToolset.WiXToolset --source winget || \
+          winget install \
+            --accept-source-agreements --accept-package-agreements --silent \
+            --id WiXToolset.WiXToolset --source winget
 
       - name: Set git params for Windows
         if: ${{ startsWith(matrix.platform, 'windows') }}

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -83,12 +83,12 @@ jobs:
                 shell="bash"
                 ;;
               windows-all-*)
-                runner="windows-latest"
+                runner="windows-2025-vs2026"
                 # igncr is required so that Cygwin doesn't get confused by Windows line endings
                 shell="C:/cygwin64/bin/bash.exe -eo pipefail -o igncr '{0}'"
                 ;;
               windows-msys2-*)
-                runner="windows-latest"
+                runner="windows-2025-vs2026"
                 # msys2.cmd is created by the msys2/setup-msys action.
                 # It typically lives at D:\a\_temp\setup-msys2\msys2.cmd
                 # and is basically a wrapper to invoke `bash.exe -leo pipefail`

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -89,6 +89,10 @@ jobs:
                 ;;
               windows-msys2-*)
                 runner="windows-latest"
+                # msys2.cmd is created by the msys2/setup-msys action.
+                # It typically lives at D:\a\_temp\setup-msys2\msys2.cmd
+                # and is basically a wrapper to invoke `bash.exe -leo pipefail`
+                # with MSYSTEM=UCRT64 and MSYS_PATH_TYPE=minimal
                 shell="msys2 '{0}'"
                 ;;
               *-aarch64 | *-arm64 | *-armhf)

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -183,6 +183,12 @@ jobs:
           # job is run in parallel.
           bundle config set --global jobs 1
 
+          # This is so that Puppet doesn't throw up when we look up Puppet.version in the
+          # openvox repo. It will think it is in a posix environment, but it should not
+          # matter for any other part of the build process.
+          # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
+          echo "root:*:0:0:::" >>/etc/passwd
+
       - name: Set git params for Windows
         if: ${{ startsWith(matrix.platform, 'windows') }}
         shell: pwsh

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -173,6 +173,7 @@ jobs:
             gcc
             make
             git
+            libffi-devel
             libyaml-devel
 
       - name: Configure MSYS2 (Windows only)

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -89,8 +89,7 @@ jobs:
                 ;;
               windows-msys2-*)
                 runner="windows-latest"
-                # igncr is required so that Cygwin doesn't get confused by Windows line endings
-                shell="C:/msys64/usr/bin/bash.exe -eo pipefail -o igncr '{0}'"
+                shell="msys2 '{0}'"
                 ;;
               *-aarch64 | *-arm64 | *-armhf)
                 runner="ubuntu-24.04-arm"
@@ -160,6 +159,29 @@ jobs:
           arch -x86_64 /usr/local/opt/ruby@3.2/bin/gem install bundler -v 2.7.2
           echo "BUNDLER_VERSION=2.7.2" >> $GITHUB_ENV
 
+      - name: Set up MSYS2 (Windows only)
+        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          # Install packages required by bundle install.
+          # Uses Cygwin-mode packages rather than Windows native packages
+          # as Vanagon expects to be interacting with a POSIX environment.
+          install: >-
+            ruby
+            gcc
+            make
+            git
+            libyaml-devel
+
+      - name: Configure MSYS2 (Windows only)
+        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
+        run: |
+          # bundle install hangs under MSYS2 Ruby when more than one
+          # job is run in parallel.
+          bundle config set --global jobs 1
+
       - name: Set git params for Windows
         if: ${{ startsWith(matrix.platform, 'windows') }}
         shell: pwsh
@@ -189,41 +211,12 @@ jobs:
           # matter for any other part of the build process.
           # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
           echo "root:*:0:0:::" | Out-File -FilePath C:\cygwin64\etc\passwd -Encoding ASCII
-          
-      - name: Install msys2 deps (Windows only)
-        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          install: mingw-w64-ucrt-x86_64-ruby git libyaml-devel gcc make
 
-      - name: Do msys stuff (Windows only)
-        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
-        shell: pwsh
-        working-directory: ${{ inputs.working_directory }}
-        run: |
-          # This is to make sure Cygwin binaries are used over preinstalled items
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # This is to fix file permissions issues when we check out code outside of Cygwin
-          echo "none /cygdrive cygdrive binary,noacl,posix=0,user 0 0" | Out-File -FilePath C:\msys64\etc\fstab -Encoding ASCII
-          # This is so that Puppet doesn't throw up when we look up Puppet.version in the
-          # openvox repo. It will think it is in a posix environment, but it should not
-          # matter for any other part of the build process.
-          # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
-          echo "root:*:0:0:::" | Out-File -FilePath C:\msys64\etc\passwd -Encoding ASCII
-          
       - name: Bundle install
         working-directory: ${{ inputs.working_directory }}
         run: |
-          cat $GITHUB_PATH
-          ls -la /ucrt64/bin
-          PATH=/ucrt64/bin/:C:/msys64/usr/bin:${PATH}
-          pacman -Sy --noconfirm mingw-w64-ucrt-x86_64-ruby git libyaml-devel mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make
-          echo "$(which ruby)"
           bundle install --retry=3
-          
+
       # from https://github.com/Sharpie/puppet-build-experiment/blob/master/resources/bolt/tasks/configure_builder.sh#L3-L14
       - name: Force docker into 32bit mode
         if: contains(matrix.platform, 'armhf')
@@ -244,11 +237,9 @@ jobs:
           PROJECT_NAME: ${{ inputs.project_name }}
           BUILD_PLATFORM: ${{ matrix.platform }}
         run: |-
-          pwd
           rm -rf output
           DESCRIBE=$(git describe --abbrev=9)
           echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
-          ls
           bundle exec rake "vox:build[${PROJECT_NAME},${BUILD_PLATFORM}]"
 
       - name: Upload build artifacts

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -82,10 +82,15 @@ jobs:
                 runner="macos-26"
                 shell="bash"
                 ;;
-              windows-*)
+              windows-all-*)
                 runner="windows-latest"
                 # igncr is required so that Cygwin doesn't get confused by Windows line endings
                 shell="C:/cygwin64/bin/bash.exe -eo pipefail -o igncr '{0}'"
+                ;;
+              windows-msys2-*)
+                runner="windows-latest"
+                # igncr is required so that Cygwin doesn't get confused by Windows line endings
+                shell="C:/msys64/usr/bin/bash.exe -eo pipefail -o igncr '{0}'"
                 ;;
               *-aarch64 | *-arm64 | *-armhf)
                 runner="ubuntu-24.04-arm"
@@ -170,7 +175,7 @@ jobs:
           fetch-depth: 0 # So we fetch all history and tags and can build non-tagged versions
 
       - name: Install Cygwin and bootstrap dependencies (Windows only)
-        if: ${{ startsWith(matrix.platform, 'windows') }}
+        if: ${{ startsWith(matrix.platform, 'windows-all') }}
         shell: pwsh
         working-directory: ${{ inputs.working_directory }}
         run: |
@@ -184,11 +189,41 @@ jobs:
           # matter for any other part of the build process.
           # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
           echo "root:*:0:0:::" | Out-File -FilePath C:\cygwin64\etc\passwd -Encoding ASCII
+          
+      - name: Install msys2 deps (Windows only)
+        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: mingw-w64-ucrt-x86_64-ruby git libyaml-devel gcc make
 
+      - name: Do msys stuff (Windows only)
+        if: ${{ startsWith(matrix.platform, 'windows-msys2') }}
+        shell: pwsh
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          # This is to make sure Cygwin binaries are used over preinstalled items
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\msys64\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # This is to fix file permissions issues when we check out code outside of Cygwin
+          echo "none /cygdrive cygdrive binary,noacl,posix=0,user 0 0" | Out-File -FilePath C:\msys64\etc\fstab -Encoding ASCII
+          # This is so that Puppet doesn't throw up when we look up Puppet.version in the
+          # openvox repo. It will think it is in a posix environment, but it should not
+          # matter for any other part of the build process.
+          # See https://github.com/OpenVoxProject/openvox/blob/5bcee89748ad1069ac31504cbc4853a6d636c2b0/lib/puppet/feature/base.rb#L13-L19
+          echo "root:*:0:0:::" | Out-File -FilePath C:\msys64\etc\passwd -Encoding ASCII
+          
       - name: Bundle install
         working-directory: ${{ inputs.working_directory }}
-        run: bundle install --retry=3
-
+        run: |
+          cat $GITHUB_PATH
+          ls -la /ucrt64/bin
+          PATH=/ucrt64/bin/:C:/msys64/usr/bin:${PATH}
+          pacman -Sy --noconfirm mingw-w64-ucrt-x86_64-ruby git libyaml-devel mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make
+          echo "$(which ruby)"
+          bundle install --retry=3
+          
       # from https://github.com/Sharpie/puppet-build-experiment/blob/master/resources/bolt/tasks/configure_builder.sh#L3-L14
       - name: Force docker into 32bit mode
         if: contains(matrix.platform, 'armhf')
@@ -209,9 +244,11 @@ jobs:
           PROJECT_NAME: ${{ inputs.project_name }}
           BUILD_PLATFORM: ${{ matrix.platform }}
         run: |-
+          pwd
           rm -rf output
           DESCRIBE=$(git describe --abbrev=9)
           echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
+          ls
           bundle exec rake "vox:build[${PROJECT_NAME},${BUILD_PLATFORM}]"
 
       - name: Upload build artifacts

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -225,6 +225,11 @@ jobs:
 
       - name: Bundle install
         working-directory: ${{ inputs.working_directory }}
+        env:
+          # Ensure only POSIX compilers and runtime libs are on the PATH.
+          # Default is UCRT64, which prioritizes /ucrt64/bin/gcc, and that
+          # breaks `bundle install` for MSYS POSIX Ruby.
+          MSYSTEM: MSYS
         run: |
           bundle install --retry=3
 

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -261,4 +261,7 @@ jobs:
           AWS_RESPONSE_CHECKSUM_VALIDATION: "WHEN_REQUIRED"
           BUILD_DESCRIBE: ${{ steps.build.outputs.describe }}
           BUILD_PLATFORM: ${{ matrix.platform }}
+          # Disable MSYS2 PATH stripping so that aws CLI installed on
+          # GitHub Runners is visible.
+          MSYS2_PATH_TYPE: inherit
         run: bundle exec rake "vox:upload[${BUILD_DESCRIBE},${BUILD_PLATFORM}]"

--- a/platforms.json
+++ b/platforms.json
@@ -31,7 +31,7 @@
       "ubuntu-26.04-amd64",
       "ubuntu-26.04-aarch64",
       "ubuntu-26.04-armhf",
-      "windows-all-x64"
+      "windows-msys2-x64"
     ],
     "ezbake-deb": [
       "ubuntu-22.04",


### PR DESCRIPTION
### Short description

This changeset adds support for a new windows-msys2-x64 platform to build OpenVox 9 under MSYS2 against the UCRT runtime. This platform exists alongside the older windows-all-x64 that builds OpenVox 8 under Cygwin against MSVCRT. The msys2/setup-msys2 GitHub action is used to provision the required components.

This is PR #95, with:

  - additional changes needed by the `openvox-agent` build
  - some additional commentary and cleanup

Credit to @sebastianrakel for the initial implementation.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
