### PR TITLE
Add arm64 support to beaker acceptance

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -172,9 +172,7 @@ jobs:
                 "beaker-options": {
                   "helper":       "lib/helper.rb"
                 },
-                "os-add": [
-                  ["debian", "13", "amd64", "daily-latest"]
-                ],
+                "os-add": [],
                 "vms": [
                   {
                     "role": "agent",

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -496,6 +496,18 @@ jobs:
           jq 'add' beaker.yml.inputs | yq -P > .beaker.yml
           cat .beaker.yml
 
+      - name: Increase timeouts for arm64 guests running under qemu
+        if: inputs.guest-arch == 'arm64' && runner.arch != 'ARM64'
+        working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
+        run: |-
+          # Double the default timeouts (a Beaker pre-suite step
+          # will take update the actual defaults/units)
+          yq -i \
+            '.["master-start-curl-retries"]   = 240 |
+             .["puppetserver-start-timeout"]  = 600 |
+             .["puppetserver-reload-timeout"] = 240' .beaker.yml
+          cat .beaker.yml
+
       - name: Run Beaker
         working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
         run: |-

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -86,6 +86,21 @@ on:
         required: false
         type: string
         default: 'https://s3.osuosl.org/openvox-artifacts'
+      guest-arch:
+        description: |-
+          The architecture of the guest VMs to run the acceptance tests
+          on. This is used by the nested_vms action to determine which
+          VM images to use.
+
+          If not provided, the default is x86_64.
+
+          NOTE: Currently only x86_64 *runners* support nested
+          virtualization, so if guest-arch is set to arm64, the
+          nested_vms will run under qemu and be quite a bit slower
+          (5x-20x).
+        required: false
+        type: string
+        default: 'x86_64'
 
 env:
   # Suppress warnings about Bolt gem versus package use.
@@ -343,7 +358,7 @@ jobs:
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || 'x86_64' }}
+          os-arch: ${{ matrix.os[2] || inputs.guest-arch || 'x86_64' }}
           image_version: ${{ matrix.os[3] }}
           host-root-access: true
           install-openvox: false

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -328,12 +328,19 @@ jobs:
           # and add acceptance-shard-tags to split the tests into
           # smaller groups to avoid timeouts.
           acceptance_shard_tags=$(jq -Mc '."acceptance-shard-tags"' project_defaults.json)
-          if [[ "${QEMU}" == "true" ]] &&
-             jq -e 'length > 0' <<< "${acceptance_shard_tags}" > /dev/null; then
-            echo "Running under qemu with acceptance_shard_tags set to '${acceptance_shard_tags}'; limiting os matrix."
-            limited_os_matrix=$(jq -Mc <<< "${DEFAULT_OS_ARM64_SHARDED}")
-            echo "Resetting os to ${limited_os_matrix}"
-            echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
+          if [[ "${QEMU}" == "true" ]]; then
+            if jq -e 'length > 0' <<< "${acceptance_shard_tags}" > /dev/null; then
+              echo "Running under qemu with acceptance_shard_tags set to '${acceptance_shard_tags}'; limiting os matrix."
+              limited_os_matrix=$(jq -Mc <<< "${DEFAULT_OS_ARM64_SHARDED}")
+              echo "Resetting os to ${limited_os_matrix}"
+              echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
+            elif [[ "${SUITE_NAME}" != "openvox-agent" ]]; then
+              echo "Running under qemu; excluding ubuntu from the os matrix (ubuntu arm64 guests under qemu were exceeding gha 6 hour timeouts)."
+              filter_jq='map(select(.[0] != "ubuntu"))'
+              limited_os_matrix=$(jq -Mc "${filter_jq}" <<< "${DEFAULT_OS}")
+              echo "Resetting os to ${limited_os_matrix}"
+              echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
+            fi
           fi
 
   set-matrix:

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -558,10 +558,15 @@ jobs:
         if: inputs.guest-arch == 'arm64' && runner.arch != 'ARM64'
         working-directory: ${{ env.ACCEPTANCE_WORKING_DIR }}
         run: |-
-          # Double the default timeouts (a Beaker pre-suite step
+          # Increase the default timeouts (a Beaker pre-suite step
           # will take update the actual defaults/units)
+          # curl-retries and puppetserver start and reload timeouts
+          # are used by several suites. The
+          # puppetserver-foreground-timeout is specific to the
+          # openvox-server suite.
           yq -i \
             '.["master-start-curl-retries"]   = 240 |
+             .["puppetserver-foreground-timeout"] = 360 |
              .["puppetserver-start-timeout"]  = 600 |
              .["puppetserver-reload-timeout"] = 240' .beaker.yml
           cat .beaker.yml

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -121,6 +121,7 @@ jobs:
       acceptance-working-dir: ${{ steps.set-defaults.outputs.acceptance_working_dir }}
       acceptance-pre-suite: ${{ steps.set-defaults.outputs.acceptance_pre_suite }}
       acceptance-tests: ${{ steps.set-defaults.outputs.acceptance_tests }}
+      acceptance-shard-tags: ${{ steps.set-defaults.outputs.acceptance_shard_tags }}
       beaker-options: ${{ steps.set-defaults.outputs.beaker_options }}
       os: ${{ steps.set-defaults.outputs.os }}
       os-add: ${{ steps.set-defaults.outputs.os_add }}
@@ -144,6 +145,7 @@ jobs:
               ["ubuntu", "24.04"],
               ["ubuntu", "26.04"]
             ]
+          QEMU: ${{ (inputs.guest-arch == 'arm64' && runner.arch != 'ARM64') && 'true' || 'false' }}
           PROJECT_DEFAULTS: |-
             {
               "openvox": {
@@ -157,6 +159,12 @@ jobs:
                 ],
                 "acceptance-tests": [
                   "tests"
+                ],
+                "acceptance-shard-tags": [
+                  "shard:group1",
+                  "shard:group2",
+                  "shard:group3",
+                  "shard:group4"
                 ],
                 "beaker-options": {
                   "helper":       "lib/helper.rb",
@@ -309,6 +317,18 @@ jobs:
             echo "${output_name}=${default}" >> $GITHUB_OUTPUT
           done
 
+          # If we are running under qemu, need to limit the os matrix
+          # and add acceptance-shard-tags to split the tests into
+          # smaller groups to avoid timeouts.
+          if [[ "${QEMU}" == "true" ]]; then
+            echo "Running under qemu, limiting os matrix and adding shard tags"
+            echo 'os=[["rocky", "9"], ["debian", "13"]]' >> $GITHUB_OUTPUT
+            acceptance_shard_tags=$(jq -rMc '."acceptance-shard-tags"' project_defaults.json)
+            echo "acceptance_shard_tags=${acceptance_shard_tags:-[]}" >> $GITHUB_OUTPUT
+          else
+            echo 'acceptance_shard_tags=[]' >> $GITHUB_OUTPUT
+          fi
+
   set-matrix:
     needs: set-project-defaults
     runs-on: ubuntu-24.04
@@ -337,6 +357,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJson(needs.set-matrix.outputs.os-matrix) }}
+        tags: ${{ fromJson(needs.set-project-defaults.outputs.acceptance-shard-tags) }}
     env:
       ACCEPTANCE_WORKING_DIR: |-
         ${{ format('{0}/{1}/{2}',
@@ -467,6 +488,7 @@ jobs:
             ${{ needs.set-project-defaults.outputs.acceptance-pre-suite || '[]' }}
           TESTS_ARRAY: |-
             ${{ needs.set-project-defaults.outputs.acceptance-tests || '[]' }}
+          TAGS: ${{ matrix.tags && toJson(matrix.tags) || '[]' }}
           BEAKER_OPTIONS: |-
             ${{ needs.set-project-defaults.outputs.beaker-options || '{}' }}
         run: |-
@@ -487,7 +509,8 @@ jobs:
               "preserve_hosts":            "always",
               "type":                      "aio",
               "pre_suite": ${PRE_SUITE_ARRAY},
-              "tests": ${TESTS_ARRAY}
+              "tests": ${TESTS_ARRAY},
+              "test_tag_and": ${TAGS}
             },
             ${BEAKER_OPTIONS}
           ]

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -339,6 +339,7 @@ jobs:
         env:
           OS: ${{ needs.set-project-defaults.outputs.os }}
           OS_ADD: ${{ needs.set-project-defaults.outputs.os-add }}
+          ARCH: ${{ inputs.guest-arch || 'x86_64' }}
         run: |-
           cat > matrix_inputs.json <<EOF
           [
@@ -347,7 +348,16 @@ jobs:
           ]
           EOF
           cat matrix_inputs.json
-          echo "os_matrix=$(jq --monochrome-output --compact-output 'add | unique' matrix_inputs.json)" >> $GITHUB_OUTPUT
+          unique_matrix=$(jq --monochrome-output 'add | unique' matrix_inputs.json)
+          jq_inject_arch="map( \
+            if length == 2 then \
+              . + [\"${ARCH}\"] \
+            else . end \
+          )"
+          matrix_with_arch=$(jq --monochrome-output "${jq_inject_arch}" <<< "${unique_matrix}")
+          echo -e "\nGenerated matrix with architecture:"
+          echo "${matrix_with_arch}"
+          echo "os_matrix=$(jq --monochrome-output --compact-output <<< "${matrix_with_arch}")" >> $GITHUB_OUTPUT
 
   acceptance:
     name: Acceptance Tests
@@ -379,7 +389,7 @@ jobs:
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || inputs.guest-arch || 'x86_64' }}
+          os-arch: ${{ matrix.os[2] || 'x86_64' }}
           image_version: ${{ matrix.os[3] }}
           host-root-access: true
           install-openvox: false

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -93,7 +93,7 @@ env:
   # The Ruby version to use for the project being tested.
   # This is used to install Ruby and run Bundler when
   # running the project's Beaker acceptance suite.
-  RUBY_VERSION: '3.3'
+  RUBY_VERSION: '3.4'
 
 jobs:
   set-project-defaults:

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -153,8 +153,7 @@ jobs:
                     "role": "primary",
                     "count": 1,
                     "cpus": 4,
-                    "mem_mb": 8192,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 8192
                   }
                 ]
               },
@@ -181,8 +180,7 @@ jobs:
                     "role": "agent",
                     "count": 1,
                     "cpus": 2,
-                    "mem_mb": 4096,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 4096
                   }
                 ]
               },
@@ -218,15 +216,13 @@ jobs:
                     "role": "primary",
                     "count": 1,
                     "cpus": 4,
-                    "mem_mb": 8192,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 8192
                   },
                   {
                     "role": "agent",
                     "count": 1,
                     "cpus": 2,
-                    "mem_mb": 2048,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 4096
                   }
                 ]
               },
@@ -262,15 +258,13 @@ jobs:
                     "role": "primary",
                     "count": 1,
                     "cpus": 4,
-                    "mem_mb": 8192,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 8192
                   },
                   {
                     "role": "agent",
                     "count": 1,
                     "cpus": 2,
-                    "mem_mb": 2048,
-                    "cpu_mode": "host-model"
+                    "mem_mb": 4096
                   }
                 ]
               }
@@ -355,11 +349,6 @@ jobs:
           image_version: ${{ matrix.os[3] }}
           host-root-access: true
           install-openvox: false
-          # Note: the cpu_mode is set to host-model for the sake of
-          # el-9 which expects at least x86_64-2 arch. This depends on
-          # the runner's architecture being sufficient, and there is
-          # probably a better way to get this set on the libvirt
-          # domain instead.
           vms: ${{ needs.set-project-defaults.outputs.vms }}
 
       - name: Write Install OpenVox Params

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -324,40 +324,60 @@ jobs:
             echo "Running under qemu, limiting os matrix and adding shard tags"
             echo 'os=[["rocky", "9"], ["debian", "13"]]' >> $GITHUB_OUTPUT
             acceptance_shard_tags=$(jq -rMc '."acceptance-shard-tags"' project_defaults.json)
-            echo "acceptance_shard_tags=${acceptance_shard_tags:-[]}" >> $GITHUB_OUTPUT
+            echo "acceptance_shard_tags=${acceptance_shard_tags:-null}" >> $GITHUB_OUTPUT
           else
-            echo 'acceptance_shard_tags=[]' >> $GITHUB_OUTPUT
+            echo 'acceptance_shard_tags=null' >> $GITHUB_OUTPUT
           fi
 
   set-matrix:
     needs: set-project-defaults
     runs-on: ubuntu-24.04
     outputs:
-      os-matrix: ${{ steps.set-matrix.outputs.os_matrix }}
+      job-matrix: ${{ steps.set-matrix.outputs.job_matrix }}
     steps:
       - id: set-matrix
         env:
           OS: ${{ needs.set-project-defaults.outputs.os }}
           OS_ADD: ${{ needs.set-project-defaults.outputs.os-add }}
           ARCH: ${{ inputs.guest-arch || 'x86_64' }}
+          ACCEPTANCE_SHARD_TAGS: ${{ needs.set-project-defaults.outputs.acceptance-shard-tags }}
         run: |-
-          cat > matrix_inputs.json <<EOF
+          cat > os_matrix_inputs.json <<EOF
           [
             ${OS},
             ${OS_ADD}
           ]
           EOF
-          cat matrix_inputs.json
-          unique_matrix=$(jq --monochrome-output 'add | unique' matrix_inputs.json)
+          cat os_matrix_inputs.json
+          unique_os_matrix=$(jq -M 'add | unique' os_matrix_inputs.json)
           jq_inject_arch="map( \
             if length == 2 then \
               . + [\"${ARCH}\"] \
             else . end \
           )"
-          matrix_with_arch=$(jq --monochrome-output "${jq_inject_arch}" <<< "${unique_matrix}")
-          echo -e "\nGenerated matrix with architecture:"
-          echo "${matrix_with_arch}"
-          echo "os_matrix=$(jq --monochrome-output --compact-output <<< "${matrix_with_arch}")" >> $GITHUB_OUTPUT
+          os_matrix_with_arch=$(jq -M "${jq_inject_arch}" <<< "${unique_os_matrix}")
+          echo -e "\nGenerated os-matrix with architecture:"
+          echo "${os_matrix_with_arch}"
+
+          cat > job_matrix_inputs.json <<EOF
+          {
+            "os": ${os_matrix_with_arch},
+            "tags": ${ACCEPTANCE_SHARD_TAGS}
+          }
+          EOF
+          echo -e "\nInitial job matrix inputs:"
+          cat job_matrix_inputs.json
+
+          jq_select_matrix="if \
+            (.tags | length) == 0 then \
+              {os: .os} \
+            else . \
+          end"
+          job_matrix=$(jq -M "${jq_select_matrix}" job_matrix_inputs.json)
+          echo -e "\nFinal job matrix:"
+          echo "${job_matrix}"
+
+          echo "job_matrix=$(jq -Mc <<<"${job_matrix}")" >> $GITHUB_OUTPUT
 
   acceptance:
     name: Acceptance Tests
@@ -365,9 +385,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
-      matrix:
-        os: ${{ fromJson(needs.set-matrix.outputs.os-matrix) }}
-        tags: ${{ fromJson(needs.set-project-defaults.outputs.acceptance-shard-tags) }}
+      matrix: ${{ fromJson(needs.set-matrix.outputs.job-matrix) }}
     env:
       ACCEPTANCE_WORKING_DIR: |-
         ${{ format('{0}/{1}/{2}',

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -217,7 +217,7 @@ jobs:
                 "install-termini": true,
                 "acceptance-working-dir": "./",
                 "acceptance-pre-suite": [
-                  "acceptance/suites/pre_suite/openvox/configure_type_defaults.rb",
+                  "acceptance/suites/pre_suite/openvox",
                   "acceptance/suites/pre_suite/foss/00_setup_environment.rb",
                   "acceptance/suites/pre_suite/foss/070_InstallCACerts.rb",
                   "acceptance/suites/pre_suite/foss/10_update_ca_certs.rb",

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -145,6 +145,11 @@ jobs:
               ["ubuntu", "24.04"],
               ["ubuntu", "26.04"]
             ]
+          DEFAULT_OS_ARM64_SHARDED: |-
+            [
+              ["rocky", "9"],
+              ["debian", "13"]
+            ]
           QEMU: ${{ (inputs.guest-arch == 'arm64' && runner.arch != 'ARM64') && 'true' || 'false' }}
           PROJECT_DEFAULTS: |-
             {
@@ -305,6 +310,7 @@ jobs:
             "acceptance-working-dir"
             "acceptance-pre-suite"
             "acceptance-tests"
+            "acceptance-shard-tags"
             "beaker-options"
             "os"
             "os-add"
@@ -317,16 +323,17 @@ jobs:
             echo "${output_name}=${default}" >> $GITHUB_OUTPUT
           done
 
-          # If we are running under qemu, need to limit the os matrix
+          # If we are running under qemu and the defaults includes
+          # acceptance-shard-tags, need to limit the os matrix
           # and add acceptance-shard-tags to split the tests into
           # smaller groups to avoid timeouts.
-          if [[ "${QEMU}" == "true" ]]; then
-            echo "Running under qemu, limiting os matrix and adding shard tags"
-            echo 'os=[["rocky", "9"], ["debian", "13"]]' >> $GITHUB_OUTPUT
-            acceptance_shard_tags=$(jq -rMc '."acceptance-shard-tags"' project_defaults.json)
-            echo "acceptance_shard_tags=${acceptance_shard_tags:-null}" >> $GITHUB_OUTPUT
-          else
-            echo 'acceptance_shard_tags=null' >> $GITHUB_OUTPUT
+          acceptance_shard_tags=$(jq -Mc '."acceptance-shard-tags"' project_defaults.json)
+          if [[ "${QEMU}" == "true" ]] &&
+             jq -e 'length > 0' <<< "${acceptance_shard_tags}" > /dev/null; then
+            echo "Running under qemu with acceptance_shard_tags set to '${acceptance_shard_tags}'; limiting os matrix."
+            limited_os_matrix=$(jq -Mc <<< "${DEFAULT_OS_ARM64_SHARDED}")
+            echo "Resetting os to ${limited_os_matrix}"
+            echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
           fi
 
   set-matrix:

--- a/README.md
+++ b/README.md
@@ -51,3 +51,51 @@ openvox-server repositories in the `.github/workflows` directory.
 
 See [beaker_acceptance.yml](.github/workflows/beaker_acceptance.yml)
 for parameter details.
+
+#### Arm64 Support
+
+You can run the `beaker_acceptance` workflow on arm64 guests in gha by
+setting `guest_arch` to `arm64`. Currently though this has serious
+limitations due to the lack of kvm support on the gha arm64 runners.
+
+* https://github.com/actions/runner-images/issues/14062
+
+Consequently, the kvm_automation_tooling module runs the arm64 guests
+emulated with qemu instead, and they are *very* slow. Many of the
+suites hit the gha 6 hour job timeout if run without special
+provisions.
+
+The workflow makes several adjustments when it detects that it will be
+running the guests in qemu.
+
+For openvox it reduces the os platforms to DEFAULT_OS_ARM64_PLATFORMS
+and adds acceptance-shard-tags to the the job matrix to limit the
+number of tests executed per runner. With these two concessions, the
+openvox suite completes in about 4 hours (at least on the couple of
+platforms in that default matrix).
+
+The openvox-agent suite runs normally, albeit slowly. Except that
+rocky10 fails currently because `which` is not installed on the arm64
+image for unknown reasons, and this breaks the
+openvox/packaging/acceptance/tests/validate_vendored_ruby.rb test.
+
+For openvox-server, all the ubuntu platforms are removed from the
+matrix, as they are by far the slowest. Alma9/rocky9 are known to
+complete successfully at the moment. The other platforms have
+scattered but consistent timing failures, mostly related to ssh?
+Except el10 which has a postgresql repo gpg key issue that I did not
+run down.
+
+For openvoxdb, ubuntu platforms are removed as well, but no work has
+been done in the openvoxdb suite to accomodate timeouts and such, and
+it generally fails in the presuite.
+
+In general, the workflow adds additional timeouts to the .beaker.yml
+configuration, though again, those are only helpful if the beaker
+suite being run makes use of them. Currently openvox and
+openvox-server suites do, but openvoxdb does not.
+
+I don't know why ubuntu qemu arm64 runs 2-4x slower than el/debian,
+but it does and was consistently hitting the 6 hour gha job timeout on
+all the suites except openvox-agent, which is why it's excluded
+everywhere but there.


### PR DESCRIPTION
### Short description

Adds a guest-arch parameter to beaker_acceptance workflow.

Allows control of the guest vm architecture when requesting a
beaker_acceptance run for a suite. This can be used to run a given suite
against arm64 vms instead of x86_64.

Also performs some maintenance updates to beaker_acceptance:

* Bump beaker_acceptance workflow to Ruby 3.4
* Drop host-model from beaker_acceptance vm specs
* Drop extra debian-13 os-add entry from beaker_acceptance

Notes on current limitations related to arm64 emulation with qemu are in the README.md.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
