### PR TITLE
Generate acceptance matrix from platforms.json

### DIFF
--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -126,222 +126,38 @@ jobs:
       os: ${{ steps.set-defaults.outputs.os }}
       os-add: ${{ steps.set-defaults.outputs.os_add }}
       vms: ${{ steps.set-defaults.outputs.vms }}
+      server-capable-os: ${{ steps.set-defaults.outputs.server_capable_os }}
+      server-fallback-os: ${{ steps.set-defaults.outputs.server_fallback_os }}
     steps:
+      - name: Checkout platform config
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OpenVoxProject/shared-actions
+          ref: main
+          path: .shared-actions
+          sparse-checkout: |
+            platforms.json
+            scripts
+          sparse-checkout-cone-mode: false
+
       - id: set-defaults
         env:
           SUITE_NAME: ${{ inputs.suite-name }}
-          DEFAULT_OS: |-
-            [
-              ["almalinux", "8"],
-              ["almalinux", "9"],
-              ["almalinux", "10"],
-              ["debian", "11"],
-              ["debian", "12"],
-              ["debian", "13"],
-              ["rocky", "8"],
-              ["rocky", "9"],
-              ["rocky", "10"],
-              ["ubuntu", "22.04"],
-              ["ubuntu", "24.04"],
-              ["ubuntu", "26.04"]
-            ]
-          DEFAULT_OS_ARM64_SHARDED: |-
-            [
-              ["rocky", "9"],
-              ["debian", "13"]
-            ]
+          OPENVOX_COLLECTION: ${{ inputs.openvox-collection }}
           QEMU: ${{ (inputs.guest-arch == 'arm64' && runner.arch != 'ARM64') && 'true' || 'false' }}
-          PROJECT_DEFAULTS: |-
-            {
-              "openvox": {
-                "repository": "openvox",
-                "install-openvox-server": true,
-                "install-openvoxdb": false,
-                "install-termini": false,
-                "acceptance-working-dir": "acceptance",
-                "acceptance-pre-suite": [
-                  "pre-suite"
-                ],
-                "acceptance-tests": [
-                  "tests"
-                ],
-                "acceptance-shard-tags": [
-                  "shard:group1",
-                  "shard:group2",
-                  "shard:group3",
-                  "shard:group4"
-                ],
-                "beaker-options": {
-                  "helper":       "lib/helper.rb",
-                  "options_file": "config/aio/options.rb"
-                },
-                "os-add": [],
-                "vms": [
-                  {
-                    "role": "primary",
-                    "count": 1,
-                    "cpus": 4,
-                    "mem_mb": 8192
-                  }
-                ]
-              },
-              "openvox-agent": {
-                "repository": "openvox",
-                "install-openvox-server": false,
-                "install-openvoxdb": false,
-                "install-termini": false,
-                "acceptance-working-dir": "packaging/acceptance",
-                "acceptance-pre-suite": [
-                  "pre-suite/configure_type_defaults.rb"
-                ],
-                "acceptance-tests": [
-                  "tests"
-                ],
-                "beaker-options": {
-                  "helper":       "lib/helper.rb"
-                },
-                "os-add": [],
-                "vms": [
-                  {
-                    "role": "agent",
-                    "count": 1,
-                    "cpus": 2,
-                    "mem_mb": 4096
-                  }
-                ]
-              },
-              "openvox-server": {
-                "repository": "openvox-server",
-                "install-openvox-server": true,
-                "install-openvoxdb": true,
-                "install-termini": true,
-                "acceptance-working-dir": "./",
-                "acceptance-pre-suite": [
-                  "acceptance/suites/pre_suite/openvox",
-                  "acceptance/suites/pre_suite/foss/00_setup_environment.rb",
-                  "acceptance/suites/pre_suite/foss/070_InstallCACerts.rb",
-                  "acceptance/suites/pre_suite/foss/10_update_ca_certs.rb",
-                  "acceptance/suites/pre_suite/foss/15_prep_locales.rb",
-                  "acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb",
-                  "acceptance/suites/pre_suite/foss/80_configure_puppet.rb",
-                  "acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb",
-                  "acceptance/suites/pre_suite/foss/95_install_pdb.rb",
-                  "acceptance/suites/pre_suite/foss/99_collect_data.rb"
-                ],
-                "acceptance-tests": [
-                  "acceptance/suites/tests"
-                ],
-                "beaker-options": {
-                  "helper":       "acceptance/lib/helper.rb",
-                  "load_path":    "acceptance/lib",
-                  "options_file": "acceptance/config/beaker/options.rb"
-                },
-                "os-add": [],
-                "vms": [
-                  {
-                    "role": "primary",
-                    "count": 1,
-                    "cpus": 4,
-                    "mem_mb": 8192
-                  },
-                  {
-                    "role": "agent",
-                    "count": 1,
-                    "cpus": 2,
-                    "mem_mb": 4096
-                  }
-                ]
-              },
-              "openvoxdb": {
-                "repository": "openvoxdb",
-                "install-openvox-server": true,
-                "install-openvoxdb": true,
-                "install-termini": true,
-                "acceptance-working-dir": "./",
-                "acceptance-pre-suite": [
-                  "acceptance/setup/openvox/configure_type_defaults.rb",
-                  "acceptance/setup/pre_suite/00_setup_test_env.rb",
-                  "acceptance/setup/pre_suite/10_setup_proxies.rb",
-                  "acceptance/setup/pre_suite/15_prep_locales.rb",
-                  "acceptance/setup/pre_suite/20_install_puppet.rb",
-                  "acceptance/setup/pre_suite/30_generate_ssl_certs.rb",
-                  "acceptance/setup/pre_suite/40_install_deps.rb",
-                  "acceptance/setup/pre_suite/50_install_modules.rb",
-                  "acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb",
-                  "acceptance/setup/pre_suite/80_add_dev_repo.rb",
-                  "acceptance/setup/openvox/configure_openvoxdb.rb"
-                ],
-                "acceptance-tests": [
-                  "acceptance/tests"
-                ],
-                "beaker-options": {
-                  "helper":       "acceptance/helper.rb",
-                  "options_file": "acceptance/options/openvox.rb"
-                },
-                "os-add": [],
-                "vms": [
-                  {
-                    "role": "primary",
-                    "count": 1,
-                    "cpus": 4,
-                    "mem_mb": 8192
-                  },
-                  {
-                    "role": "agent",
-                    "count": 1,
-                    "cpus": 2,
-                    "mem_mb": 4096
-                  }
-                ]
-              }
-            }
         run: |-
           set -e
-
-          # Pick out the defaults for the project being tested.
-          jq ".\"${SUITE_NAME}\" | .os = ${DEFAULT_OS}" <<< "${PROJECT_DEFAULTS}" > project_defaults.json
-          cat project_defaults.json
-
-          parameters=(
-            "repository"
-            "install-openvox-server"
-            "install-openvoxdb"
-            "install-termini"
-            "acceptance-working-dir"
-            "acceptance-pre-suite"
-            "acceptance-tests"
-            "acceptance-shard-tags"
-            "beaker-options"
-            "os"
-            "os-add"
-            "vms"
-          )
-          for param in "${parameters[@]}"; do
-            output_name=${param//-/_}
-            default=$(jq -rMc ".\"${param}\"" project_defaults.json)
-            echo "Setting ${output_name} to ${default}"
-            echo "${output_name}=${default}" >> $GITHUB_OUTPUT
-          done
-
-          # If we are running under qemu and the defaults includes
-          # acceptance-shard-tags, need to limit the os matrix
-          # and add acceptance-shard-tags to split the tests into
-          # smaller groups to avoid timeouts.
-          acceptance_shard_tags=$(jq -Mc '."acceptance-shard-tags"' project_defaults.json)
-          if [[ "${QEMU}" == "true" ]]; then
-            if jq -e 'length > 0' <<< "${acceptance_shard_tags}" > /dev/null; then
-              echo "Running under qemu with acceptance_shard_tags set to '${acceptance_shard_tags}'; limiting os matrix."
-              limited_os_matrix=$(jq -Mc <<< "${DEFAULT_OS_ARM64_SHARDED}")
-              echo "Resetting os to ${limited_os_matrix}"
-              echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
-            elif [[ "${SUITE_NAME}" != "openvox-agent" ]]; then
-              echo "Running under qemu; excluding ubuntu from the os matrix (ubuntu arm64 guests under qemu were exceeding gha 6 hour timeouts)."
-              filter_jq='map(select(.[0] != "ubuntu"))'
-              limited_os_matrix=$(jq -Mc "${filter_jq}" <<< "${DEFAULT_OS}")
-              echo "Resetting os to ${limited_os_matrix}"
-              echo "os=${limited_os_matrix}" >> $GITHUB_OUTPUT
-            fi
-          fi
+          # Compute the suite's acceptance config and derived OS matrix from
+          # platforms.json (see .shared-actions/scripts/project-config.sh).
+          config=$(.shared-actions/scripts/project-config.sh \
+            "${SUITE_NAME}" "${OPENVOX_COLLECTION}" "${QEMU}")
+          echo "Computed acceptance config:"
+          jq . <<< "${config}"
+          # Emit every config key as a step output (hyphens -> underscores).
+          # String values are written raw; arrays and objects as compact JSON.
+          jq -r 'to_entries[]
+            | "\(.key | gsub("-"; "_"))=\(.value | if type == "string" then . else tojson end)"' \
+            <<< "${config}" >> "$GITHUB_OUTPUT"
 
   set-matrix:
     needs: set-project-defaults
@@ -349,6 +165,15 @@ jobs:
     outputs:
       job-matrix: ${{ steps.set-matrix.outputs.job_matrix }}
     steps:
+      - name: Checkout acceptance scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OpenVoxProject/shared-actions
+          ref: main
+          path: .shared-actions
+          sparse-checkout: scripts
+          sparse-checkout-cone-mode: false
+
       - id: set-matrix
         env:
           OS: ${{ needs.set-project-defaults.outputs.os }}
@@ -356,42 +181,12 @@ jobs:
           ARCH: ${{ inputs.guest-arch || 'x86_64' }}
           ACCEPTANCE_SHARD_TAGS: ${{ needs.set-project-defaults.outputs.acceptance-shard-tags }}
         run: |-
-          cat > os_matrix_inputs.json <<EOF
-          [
-            ${OS},
-            ${OS_ADD}
-          ]
-          EOF
-          cat os_matrix_inputs.json
-          unique_os_matrix=$(jq -M 'add | unique' os_matrix_inputs.json)
-          jq_inject_arch="map( \
-            if length == 2 then \
-              . + [\"${ARCH}\"] \
-            else . end \
-          )"
-          os_matrix_with_arch=$(jq -M "${jq_inject_arch}" <<< "${unique_os_matrix}")
-          echo -e "\nGenerated os-matrix with architecture:"
-          echo "${os_matrix_with_arch}"
-
-          cat > job_matrix_inputs.json <<EOF
-          {
-            "os": ${os_matrix_with_arch},
-            "tags": ${ACCEPTANCE_SHARD_TAGS}
-          }
-          EOF
-          echo -e "\nInitial job matrix inputs:"
-          cat job_matrix_inputs.json
-
-          jq_select_matrix="if \
-            (.tags | length) == 0 then \
-              {os: .os} \
-            else . \
-          end"
-          job_matrix=$(jq -M "${jq_select_matrix}" job_matrix_inputs.json)
-          echo -e "\nFinal job matrix:"
-          echo "${job_matrix}"
-
-          echo "job_matrix=$(jq -Mc <<<"${job_matrix}")" >> $GITHUB_OUTPUT
+          set -e
+          job_matrix=$(.shared-actions/scripts/build-job-matrix.sh \
+            "${OS}" "${OS_ADD}" "${ARCH}" "${ACCEPTANCE_SHARD_TAGS}")
+          echo "Job matrix:"
+          jq . <<< "${job_matrix}"
+          echo "job_matrix=${job_matrix}" >> "$GITHUB_OUTPUT"
 
   acceptance:
     name: Acceptance Tests
@@ -416,16 +211,48 @@ jobs:
           ref: ${{ inputs.ref }}
           path: ${{ needs.set-project-defaults.outputs.repository }}
 
+      - name: Checkout acceptance scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: OpenVoxProject/shared-actions
+          ref: main
+          path: .shared-actions
+          sparse-checkout: scripts
+          sparse-checkout-cone-mode: false
+
+      - id: set-topology
+        name: Build cluster topology
+        env:
+          SUITE_NAME: ${{ inputs.suite-name }}
+          NATIVE_OS: ${{ matrix.os[0] }}
+          NATIVE_VER: ${{ matrix.os[1] }}
+          NATIVE_ARCH: ${{ matrix.os[2] || 'x86_64' }}
+          BASE_VMS: ${{ needs.set-project-defaults.outputs.vms }}
+          SERVER_CAPABLE_OS: ${{ needs.set-project-defaults.outputs.server-capable-os }}
+          SERVER_FALLBACK_OS: ${{ needs.set-project-defaults.outputs.server-fallback-os }}
+        run: |-
+          set -e
+          # Resolve the VM cluster for this cell, applying the openvox
+          # server-fallback when needed (see
+          # .shared-actions/scripts/build-cluster-topology.sh).
+          topology=$(.shared-actions/scripts/build-cluster-topology.sh \
+            "${SUITE_NAME}" "${NATIVE_OS}" "${NATIVE_VER}" "${NATIVE_ARCH}" \
+            "${BASE_VMS}" "${SERVER_CAPABLE_OS}" "${SERVER_FALLBACK_OS}")
+          echo "Cluster topology:"
+          jq . <<< "${topology}"
+          jq -r 'to_entries[] | "\(.key)=\(.value | if type == "string" then . else tojson end)"' \
+            <<< "${topology}" >> "$GITHUB_OUTPUT"
+
       - id: vm-cluster
         uses: jpartlow/nested_vms@7f2caec8ae0a5c01eb8780cdb5891bd96acfab3e # 1.4.0
         with:
-          os: ${{ matrix.os[0] }}
-          os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || 'x86_64' }}
+          os: ${{ steps.set-topology.outputs.os }}
+          os-version: ${{ steps.set-topology.outputs.os_version }}
+          os-arch: ${{ steps.set-topology.outputs.os_arch }}
           image_version: ${{ matrix.os[3] }}
           host-root-access: true
           install-openvox: false
-          vms: ${{ needs.set-project-defaults.outputs.vms }}
+          vms: ${{ steps.set-topology.outputs.vms }}
 
       - name: Write Install OpenVox Params
         working-directory: kvm_automation_tooling

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -132,8 +132,8 @@ jobs:
       - name: Checkout platform config
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: OpenVoxProject/shared-actions
-          ref: main
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .shared-actions
           sparse-checkout: |
             platforms.json
@@ -168,8 +168,8 @@ jobs:
       - name: Checkout acceptance scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: OpenVoxProject/shared-actions
-          ref: main
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .shared-actions
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false
@@ -214,8 +214,8 @@ jobs:
       - name: Checkout acceptance scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: OpenVoxProject/shared-actions
-          ref: main
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .shared-actions
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -121,10 +121,7 @@ jobs:
       acceptance-working-dir: ${{ steps.set-defaults.outputs.acceptance_working_dir }}
       acceptance-pre-suite: ${{ steps.set-defaults.outputs.acceptance_pre_suite }}
       acceptance-tests: ${{ steps.set-defaults.outputs.acceptance_tests }}
-      acceptance-shard-tags: ${{ steps.set-defaults.outputs.acceptance_shard_tags }}
       beaker-options: ${{ steps.set-defaults.outputs.beaker_options }}
-      os: ${{ steps.set-defaults.outputs.os }}
-      os-add: ${{ steps.set-defaults.outputs.os_add }}
       vms: ${{ steps.set-defaults.outputs.vms }}
       server-capable-os: ${{ steps.set-defaults.outputs.server_capable_os }}
       server-fallback-os: ${{ steps.set-defaults.outputs.server_fallback_os }}
@@ -171,19 +168,21 @@ jobs:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
           path: .shared-actions
-          sparse-checkout: scripts
+          sparse-checkout: |
+            platforms.json
+            scripts
           sparse-checkout-cone-mode: false
 
       - id: set-matrix
         env:
-          OS: ${{ needs.set-project-defaults.outputs.os }}
-          OS_ADD: ${{ needs.set-project-defaults.outputs.os-add }}
+          SUITE_NAME: ${{ inputs.suite-name }}
+          OPENVOX_COLLECTION: ${{ inputs.openvox-collection }}
           ARCH: ${{ inputs.guest-arch || 'x86_64' }}
-          ACCEPTANCE_SHARD_TAGS: ${{ needs.set-project-defaults.outputs.acceptance-shard-tags }}
+          QEMU: ${{ (inputs.guest-arch == 'arm64' && runner.arch != 'ARM64') && 'true' || 'false' }}
         run: |-
           set -e
           job_matrix=$(.shared-actions/scripts/build-job-matrix.sh \
-            "${OS}" "${OS_ADD}" "${ARCH}" "${ACCEPTANCE_SHARD_TAGS}")
+            "${SUITE_NAME}" "${OPENVOX_COLLECTION}" "${ARCH}" "${QEMU}")
           echo "Job matrix:"
           jq . <<< "${job_matrix}"
           echo "job_matrix=${job_matrix}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/beaker_acceptance.yml
+++ b/.github/workflows/beaker_acceptance.yml
@@ -122,9 +122,6 @@ jobs:
       acceptance-pre-suite: ${{ steps.set-defaults.outputs.acceptance_pre_suite }}
       acceptance-tests: ${{ steps.set-defaults.outputs.acceptance_tests }}
       beaker-options: ${{ steps.set-defaults.outputs.beaker_options }}
-      vms: ${{ steps.set-defaults.outputs.vms }}
-      server-capable-os: ${{ steps.set-defaults.outputs.server_capable_os }}
-      server-fallback-os: ${{ steps.set-defaults.outputs.server_fallback_os }}
     steps:
       - name: Checkout platform config
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -216,27 +213,27 @@ jobs:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
           path: .shared-actions
-          sparse-checkout: scripts
+          sparse-checkout: |
+            platforms.json
+            scripts
           sparse-checkout-cone-mode: false
 
       - id: set-topology
         name: Build cluster topology
         env:
           SUITE_NAME: ${{ inputs.suite-name }}
+          OPENVOX_COLLECTION: ${{ inputs.openvox-collection }}
           NATIVE_OS: ${{ matrix.os[0] }}
           NATIVE_VER: ${{ matrix.os[1] }}
           NATIVE_ARCH: ${{ matrix.os[2] || 'x86_64' }}
-          BASE_VMS: ${{ needs.set-project-defaults.outputs.vms }}
-          SERVER_CAPABLE_OS: ${{ needs.set-project-defaults.outputs.server-capable-os }}
-          SERVER_FALLBACK_OS: ${{ needs.set-project-defaults.outputs.server-fallback-os }}
         run: |-
           set -e
           # Resolve the VM cluster for this cell, applying the openvox
           # server-fallback when needed (see
           # .shared-actions/scripts/build-cluster-topology.sh).
           topology=$(.shared-actions/scripts/build-cluster-topology.sh \
-            "${SUITE_NAME}" "${NATIVE_OS}" "${NATIVE_VER}" "${NATIVE_ARCH}" \
-            "${BASE_VMS}" "${SERVER_CAPABLE_OS}" "${SERVER_FALLBACK_OS}")
+            "${SUITE_NAME}" "${OPENVOX_COLLECTION}" \
+            "${NATIVE_OS}" "${NATIVE_VER}" "${NATIVE_ARCH}")
           echo "Cluster topology:"
           jq . <<< "${topology}"
           jq -r 'to_entries[] | "\(.key)=\(.value | if type == "string" then . else tojson end)"' \

--- a/scripts/build-cluster-topology.sh
+++ b/scripts/build-cluster-topology.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Build the VM cluster for a single acceptance matrix cell.
+#
+# For the openvox suite (agent + co-located server) an OS may have an agent
+# build but no server build. In that case the server (the "primary" VM, which
+# Beaker treats as master/database) is pinned to a fallback OS and a dedicated
+# agent VM is added on the native OS under test, so agent coverage on the native
+# OS is preserved. Every other case runs natively with the suite's base vm spec.
+#
+# Usage:
+#   build-cluster-topology.sh <suite> <native_os> <native_ver> <native_arch> \
+#       <base_vms_json> <server_capable_os_json> <server_fallback_os_json>
+#
+# Prints a JSON object: { "os", "os_version", "os_arch", "vms" }
+# where os/os_version/os_arch are the nested_vms cluster defaults (the OS any vm
+# spec without its own override inherits) and vms is the resolved vm spec array.
+set -euo pipefail
+
+suite=${1:?}
+native_os=${2:?}
+native_ver=${3:?}
+native_arch=${4:?}
+base_vms=${5:?}
+server_capable_os=${6:?}
+server_fallback_os=${7:?}
+
+os=$native_os
+os_version=$native_ver
+os_arch=$native_arch
+vms=$base_vms
+
+if [[ "$suite" == "openvox" ]]; then
+  native_pair=$(jq -cn --arg n "$native_os" --arg v "$native_ver" '[$n, $v]')
+  if ! jq -e --argjson p "$native_pair" 'any(. == $p)' <<<"$server_capable_os" >/dev/null; then
+    fb_name=$(jq -r '.[0]' <<<"$server_fallback_os")
+    fb_ver=$(jq -r '.[1]' <<<"$server_fallback_os")
+    echo "Native OS ${native_os}-${native_ver} has no server build; running the server on ${fb_name}-${fb_ver}." >&2
+    # The nested_vms cluster default OS stays native (inherited by the agent);
+    # the primary/server is pinned to the fallback OS via a per-vm os override.
+    vms=$(jq -c \
+      --arg fn "$fb_name" --arg fv "$fb_ver" --arg fa "$native_arch" \
+      'map(if .role == "primary"
+            then . + {os: {name: $fn, version: $fv, arch: $fa}}
+            else . end)
+       + [{role: "agent", count: 1, cpus: 2, mem_mb: 4096}]' \
+      <<<"$base_vms")
+  fi
+fi
+
+jq -cn \
+  --arg os "$os" \
+  --arg os_version "$os_version" \
+  --arg os_arch "$os_arch" \
+  --argjson vms "$vms" \
+  '{os: $os, os_version: $os_version, os_arch: $os_arch, vms: $vms}'

--- a/scripts/build-cluster-topology.sh
+++ b/scripts/build-cluster-topology.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Build the VM cluster for a single acceptance matrix cell.
+# Build the VM cluster configuration for jpartlow/nested_vms, for a single
+# acceptance matrix cell.
 #
 # For the openvox suite (agent + co-located server) an OS may have an agent
 # build but no server build. In that case the server (the "primary" VM, which
@@ -9,37 +10,47 @@
 # OS is preserved. Every other case runs natively with the suite's base vm spec.
 #
 # Usage:
-#   build-cluster-topology.sh <suite> <native_os> <native_ver> <native_arch> \
-#       <base_vms_json> <server_capable_os_json> <server_fallback_os_json>
+#   build-cluster-topology.sh <suite> <collection> <os> <os_version> [<arch>]
+#
+#   suite       openvox | openvox-agent | openvox-server | openvoxdb
+#   collection  openvox collection (openvox9 -> main, openvox8 -> 8.x, else main)
+#   os          name of operating system to use. See "universe" varaiable in project.config.sh
+#   os_ver      version of operating system to use.
+#   arch        architecture of guest VMs to run. Defaults to x86_64.
+#
+# Example:
+#   ./scripts/build-cluster-topology.sh openvox openvox9 debian 11 | jq .
 #
 # Prints a JSON object: { "os", "os_version", "os_arch", "vms" }
 # where os/os_version/os_arch are the nested_vms cluster defaults (the OS any vm
 # spec without its own override inherits) and vms is the resolved vm spec array.
 set -euo pipefail
 
-suite=${1:?}
-native_os=${2:?}
-native_ver=${3:?}
-native_arch=${4:?}
-base_vms=${5:?}
-server_capable_os=${6:?}
-server_fallback_os=${7:?}
+suite=${1:?usage: build-cluster-topology.sh <suite> <collection> <os> <os_ver> <arch>}
+collection=${2:?usage: build-cluster-topology.sh <suite> <collection> <os> <os_ver> <arch>}
+os=${3:?usage: build-cluster-topology.sh <suite> <collection> <os> <os_ver> <arch>}
+os_ver=${4:?usage: build-cluster-topology.sh <suite> <collection> <os> <os_ver> <arch>}
+arch=${5:-x86_64}
 
-os=$native_os
-os_version=$native_ver
-os_arch=$native_arch
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+project_config=$("${script_dir}/project-config.sh" "${suite}" "${collection}")
+
+base_vms=$(jq -c '.vms' <<<"${project_config}")
+server_capable_os=$(jq -c '."server-capable-os"' <<<"${project_config}")
+server_fallback_os=$(jq -c '."server-fallback-os"' <<<"${project_config}")
+
 vms=$base_vms
 
 if [[ "$suite" == "openvox" ]]; then
-  native_pair=$(jq -cn --arg n "$native_os" --arg v "$native_ver" '[$n, $v]')
+  native_pair=$(jq -cn --arg n "$os" --arg v "$os_ver" '[$n, $v]')
   if ! jq -e --argjson p "$native_pair" 'any(. == $p)' <<<"$server_capable_os" >/dev/null; then
     fb_name=$(jq -r '.[0]' <<<"$server_fallback_os")
     fb_ver=$(jq -r '.[1]' <<<"$server_fallback_os")
-    echo "Native OS ${native_os}-${native_ver} has no server build; running the server on ${fb_name}-${fb_ver}." >&2
+    echo "OS ${os}-${os_ver} has no server build in ${collection}; running the server on ${fb_name}-${fb_ver}." >&2
     # The nested_vms cluster default OS stays native (inherited by the agent);
     # the primary/server is pinned to the fallback OS via a per-vm os override.
     vms=$(jq -c \
-      --arg fn "$fb_name" --arg fv "$fb_ver" --arg fa "$native_arch" \
+      --arg fn "$fb_name" --arg fv "$fb_ver" --arg fa "$arch" \
       'map(if .role == "primary"
             then . + {os: {name: $fn, version: $fv, arch: $fa}}
             else . end)
@@ -50,7 +61,7 @@ fi
 
 jq -cn \
   --arg os "$os" \
-  --arg os_version "$os_version" \
-  --arg os_arch "$os_arch" \
+  --arg os_version "$os_ver" \
+  --arg os_arch "$arch" \
   --argjson vms "$vms" \
   '{os: $os, os_version: $os_version, os_arch: $os_arch, vms: $vms}'

--- a/scripts/build-job-matrix.sh
+++ b/scripts/build-job-matrix.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Build the GitHub Actions job matrix for the acceptance job.
+#
+# Combines the base OS list with any extra OSes (os-add), injects the guest arch
+# as a third element of each [os, version] pair, and folds in shard tags when
+# the suite defines them.
+#
+# Usage:
+#   build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>
+#
+# Prints the job matrix JSON, e.g.
+#   {"os":[["almalinux","9","x86_64"], ...]}
+#   {"os":[...],"tags":["shard:group1", ...]}   # when shard tags are present
+set -euo pipefail
+
+os=${1:?usage: build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>}
+os_add=${2:-'[]'}
+arch=${3:?usage: build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>}
+shard_tags=${4:-'[]'}
+
+# Concatenate base + extra OSes, de-dupe, and append the arch to each 2-element
+# [os, version] pair.
+os_with_arch=$(jq -cn \
+  --argjson os "$os" \
+  --argjson add "$os_add" \
+  --arg arch "$arch" \
+  '($os + $add) | unique | map(if length == 2 then . + [$arch] else . end)')
+
+# Only include "tags" in the matrix when there are shard tags to fan out on;
+# otherwise GitHub would create a spurious empty tag dimension.
+jq -cn \
+  --argjson os "$os_with_arch" \
+  --argjson tags "$shard_tags" \
+  'if ($tags | length) == 0 then {os: $os} else {os: $os, tags: $tags} end'

--- a/scripts/build-job-matrix.sh
+++ b/scripts/build-job-matrix.sh
@@ -2,29 +2,44 @@
 #
 # Build the GitHub Actions job matrix for the acceptance job.
 #
-# Combines the base OS list with any extra OSes (os-add), injects the guest arch
-# as a third element of each [os, version] pair, and folds in shard tags when
-# the suite defines them.
+# Calls through to project-config.sh, and then combines the base OS list with
+# any extra OSes (os-add), injects the guest arch as a third element of each
+# [os, version] pair, and folds in shard tags when the suite defines them.
 #
 # Usage:
-#   build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>
+#   build-job-matrix.sh <suite> <collection> [<arch>] [<qemu>]
+#
+#   suite       openvox | openvox-agent | openvox-server | openvoxdb
+#   collection  openvox collection (openvox9 -> main, openvox8 -> 8.x, else main)
+#   arch        architecture of guest VMs to run. Defaults to x86_64.
+#   qemu        "true" when running arm64 guests under qemu (limits the matrix)
+#
+# Example:
+#   ./scripts/build-job-matrix.sh openvox-server openvox9 | jq .
 #
 # Prints the job matrix JSON, e.g.
 #   {"os":[["almalinux","9","x86_64"], ...]}
 #   {"os":[...],"tags":["shard:group1", ...]}   # when shard tags are present
 set -euo pipefail
 
-os=${1:?usage: build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>}
-os_add=${2:-'[]'}
-arch=${3:?usage: build-job-matrix.sh <os_json> <os_add_json> <arch> <shard_tags_json>}
-shard_tags=${4:-'[]'}
+suite=${1:?usage: build-job-matrix.sh <suite> <collection> [<arch>] [<qemu>]}
+collection=${2:?usage: build-job-matrix.sh <suite> <collection> [<arch>] [<qemu>]}
+arch=${3:-x86_64}
+qemu=${5:-false}
+
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+project_config=$("${script_dir}/project-config.sh" "${suite}" "${collection}" "${qemu}")
+
+os=$(jq -c '.os' <<<"${project_config}")
+os_add=$(jq -c '."os-add"' <<<"${project_config}")
+shard_tags=$(jq -c '."acceptance-shard-tags"' <<<"${project_config}")
 
 # Concatenate base + extra OSes, de-dupe, and append the arch to each 2-element
 # [os, version] pair.
 os_with_arch=$(jq -cn \
-  --argjson os "$os" \
-  --argjson add "$os_add" \
-  --arg arch "$arch" \
+  --argjson os "${os}" \
+  --argjson add "${os_add:-'[]'}" \
+  --arg arch "${arch}" \
   '($os + $add) | unique | map(if length == 2 then . + [$arch] else . end)')
 
 # Only include "tags" in the matrix when there are shard tags to fan out on;

--- a/scripts/project-config.sh
+++ b/scripts/project-config.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Compute the acceptance test configuration (including the OS matrix) for one
+# OpenVox suite.
+#
+# The OS matrix is DERIVED from what a given release line actually builds: the
+# build platform lists in ../platforms.json are mapped to acceptance OS names
+# and intersected with the universe of OSes nested_vms can provision. This keeps
+# the acceptance matrix in step with the packages that exist, so 9.0 (main) is
+# reduced to its smaller server/db platform set while 8.x still tests the full
+# legacy list.
+#
+# The static, per-suite acceptance config lives in ./project_defaults.json; this
+# script merges the derived matrix and the openvox server-fallback information
+# into it and prints the combined JSON object on stdout.
+#
+# Usage:
+#   project-config.sh <suite> <collection> [<qemu>]
+#
+#   suite       openvox | openvox-agent | openvox-server | openvoxdb
+#   collection  openvox collection (openvox9 -> main, openvox8 -> 8.x, else main)
+#   qemu        "true" when running arm64 guests under qemu (limits the matrix)
+#
+# Environment:
+#   PLATFORMS_JSON  override the path to platforms.json (default ../platforms.json)
+#
+# Example:
+#   scripts/project-config.sh openvox-server openvox9 | jq .
+set -euo pipefail
+
+suite=${1:?usage: project-config.sh <suite> <collection> [<qemu>]}
+collection=${2:?usage: project-config.sh <suite> <collection> [<qemu>]}
+qemu=${3:-false}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+platforms="${PLATFORMS_JSON:-${script_dir}/../platforms.json}"
+project_defaults="${script_dir}/project_defaults.json"
+
+# The universe of OSes nested_vms can actually provision. The derived matrix is
+# always a subset of this, so build targets we cannot stand up as VMs (e.g. 8.x
+# el-7 -> alma/rocky 7 or ubuntu-25.04, and non-VM families like sles, fedora,
+# amazon, macos and windows) never leak into the matrix.
+universe='[
+  ["almalinux","8"],["almalinux","9"],["almalinux","10"],
+  ["debian","11"],["debian","12"],["debian","13"],
+  ["rocky","8"],["rocky","9"],["rocky","10"],
+  ["ubuntu","22.04"],["ubuntu","24.04"],["ubuntu","26.04"]
+]'
+# Under qemu, the openvox suite (which shards its tests) is limited to this
+# subset to stay under the GHA 6 hour job limit; the other suites drop ubuntu.
+arm64_sharded='[["rocky","9"],["debian","13"]]'
+
+# Map the openvox collection to a platforms.json release-line key.
+case "$collection" in
+  openvox8) branch="8.x" ;;
+  *)        branch="main" ;;
+esac
+
+# jq: turn a list of build-platform strings (e.g. "el-9", "debian-13",
+# "ubuntu-24.04-amd64") into acceptance [os, version] pairs. Arch suffixes are
+# stripped, "el-N" expands to both almalinux and rocky (which the acceptance
+# suite tests separately), and non-VM families are dropped.
+map_platforms='
+  def strip_arch: sub("-(x86_64|amd64|aarch64|arm64|armhf)$"; "");
+  def map_platform:
+    strip_arch as $s
+    | if   ($s | test("^el-[0-9]+$"))
+        then ($s | ltrimstr("el-")) as $v | [["almalinux", $v], ["rocky", $v]]
+      elif ($s | test("^debian-[0-9]+$"))
+        then [["debian", ($s | ltrimstr("debian-"))]]
+      elif ($s | test("^ubuntu-[0-9.]+$"))
+        then [["ubuntu", ($s | ltrimstr("ubuntu-"))]]
+      else [] end;
+  ([ .[] | map_platform ] | add) // [] | unique
+'
+# jq: keep only the universe entries present in the mapped build set ($set),
+# preserving universe ordering.
+intersect='. as $uni | $uni | map(select(. as $u | ($set | any(. == $u))))'
+
+# Which build list gates this suite: the agent (vanagon) list for the agent
+# suites, or the combined server/db (ezbake) list otherwise.
+case "$suite" in
+  openvox|openvox-agent)
+    build_list=$(jq -c --arg b "$branch" '.[$b].vanagon' "$platforms") ;;
+  openvox-server|openvoxdb)
+    build_list=$(jq -c --arg b "$branch" '(.[$b]["ezbake-deb"] + .[$b]["ezbake-rpm"])' "$platforms") ;;
+  *)
+    echo "Unknown suite '$suite'" >&2; exit 1 ;;
+esac
+# The server/db build list is always needed to decide when a fall back is needed
+# to test an agent platform that does not have a corresponding server build.
+server_list=$(jq -c --arg b "$branch" '(.[$b]["ezbake-deb"] + .[$b]["ezbake-rpm"])' "$platforms")
+
+# Translate platforms.json OS names to nested_vms tuples.
+build_os=$(jq -c "$map_platforms" <<<"$build_list")
+server_build_os=$(jq -c "$map_platforms" <<<"$server_list")
+
+os=$(jq -c --argjson set "$build_os" "$intersect" <<<"$universe")
+server_capable_os=$(jq -c --argjson set "$server_build_os" "$intersect" <<<"$universe")
+
+# Merge the static per-suite config with the derived matrix and server info.
+# acceptance-shard-tags defaults to [] so every suite exposes the key.
+config=$(jq -c \
+  --arg suite "$suite" \
+  --argjson os "$os" \
+  --argjson server_capable_os "$server_capable_os" \
+  '.[$suite]
+    | .os = $os
+    | .["server-capable-os"] = $server_capable_os
+    | .["server-fallback-os"] = ["debian", "13"]
+    | .["acceptance-shard-tags"] //= []' \
+  "$project_defaults")
+
+# Under qemu, limit the OS matrix. This operates on the already-derived matrix,
+# so an OS with no build is never reintroduced.
+if [[ "$qemu" == "true" ]]; then
+  shard_count=$(jq '.["acceptance-shard-tags"] | length' <<<"$config")
+  if [[ "$shard_count" -gt 0 ]]; then
+    limited=$(jq -c --argjson set "$arm64_sharded" "$intersect" <<<"$os")
+    config=$(jq -c --argjson os "$limited" '.os = $os' <<<"$config")
+  elif [[ "$suite" != "openvox-agent" ]]; then
+    limited=$(jq -c 'map(select(.[0] != "ubuntu"))' <<<"$os")
+    config=$(jq -c --argjson os "$limited" '.os = $os' <<<"$config")
+  fi
+fi
+
+echo "$config"

--- a/scripts/project_defaults.json
+++ b/scripts/project_defaults.json
@@ -1,0 +1,143 @@
+{
+  "openvox": {
+    "repository": "openvox",
+    "install-openvox-server": true,
+    "install-openvoxdb": false,
+    "install-termini": false,
+    "acceptance-working-dir": "acceptance",
+    "acceptance-pre-suite": [
+      "pre-suite"
+    ],
+    "acceptance-tests": [
+      "tests"
+    ],
+    "acceptance-shard-tags": [
+      "shard:group1",
+      "shard:group2",
+      "shard:group3",
+      "shard:group4"
+    ],
+    "beaker-options": {
+      "helper":       "lib/helper.rb",
+      "options_file": "config/aio/options.rb"
+    },
+    "os-add": [],
+    "vms": [
+      {
+        "role": "primary",
+        "count": 1,
+        "cpus": 4,
+        "mem_mb": 8192
+      }
+    ]
+  },
+  "openvox-agent": {
+    "repository": "openvox",
+    "install-openvox-server": false,
+    "install-openvoxdb": false,
+    "install-termini": false,
+    "acceptance-working-dir": "packaging/acceptance",
+    "acceptance-pre-suite": [
+      "pre-suite/configure_type_defaults.rb"
+    ],
+    "acceptance-tests": [
+      "tests"
+    ],
+    "beaker-options": {
+      "helper":       "lib/helper.rb"
+    },
+    "os-add": [],
+    "vms": [
+      {
+        "role": "agent",
+        "count": 1,
+        "cpus": 2,
+        "mem_mb": 4096
+      }
+    ]
+  },
+  "openvox-server": {
+    "repository": "openvox-server",
+    "install-openvox-server": true,
+    "install-openvoxdb": true,
+    "install-termini": true,
+    "acceptance-working-dir": "./",
+    "acceptance-pre-suite": [
+      "acceptance/suites/pre_suite/openvox",
+      "acceptance/suites/pre_suite/foss/00_setup_environment.rb",
+      "acceptance/suites/pre_suite/foss/070_InstallCACerts.rb",
+      "acceptance/suites/pre_suite/foss/10_update_ca_certs.rb",
+      "acceptance/suites/pre_suite/foss/15_prep_locales.rb",
+      "acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb",
+      "acceptance/suites/pre_suite/foss/80_configure_puppet.rb",
+      "acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb",
+      "acceptance/suites/pre_suite/foss/95_install_pdb.rb",
+      "acceptance/suites/pre_suite/foss/99_collect_data.rb"
+    ],
+    "acceptance-tests": [
+      "acceptance/suites/tests"
+    ],
+    "beaker-options": {
+      "helper":       "acceptance/lib/helper.rb",
+      "load_path":    "acceptance/lib",
+      "options_file": "acceptance/config/beaker/options.rb"
+    },
+    "os-add": [],
+    "vms": [
+      {
+        "role": "primary",
+        "count": 1,
+        "cpus": 4,
+        "mem_mb": 8192
+      },
+      {
+        "role": "agent",
+        "count": 1,
+        "cpus": 2,
+        "mem_mb": 4096
+      }
+    ]
+  },
+  "openvoxdb": {
+    "repository": "openvoxdb",
+    "install-openvox-server": true,
+    "install-openvoxdb": true,
+    "install-termini": true,
+    "acceptance-working-dir": "./",
+    "acceptance-pre-suite": [
+      "acceptance/setup/openvox/configure_type_defaults.rb",
+      "acceptance/setup/pre_suite/00_setup_test_env.rb",
+      "acceptance/setup/pre_suite/10_setup_proxies.rb",
+      "acceptance/setup/pre_suite/15_prep_locales.rb",
+      "acceptance/setup/pre_suite/20_install_puppet.rb",
+      "acceptance/setup/pre_suite/30_generate_ssl_certs.rb",
+      "acceptance/setup/pre_suite/40_install_deps.rb",
+      "acceptance/setup/pre_suite/50_install_modules.rb",
+      "acceptance/setup/pre_suite/75_clean_out_puppet5_repos.rb",
+      "acceptance/setup/pre_suite/80_add_dev_repo.rb",
+      "acceptance/setup/openvox/configure_openvoxdb.rb"
+    ],
+    "acceptance-tests": [
+      "acceptance/tests"
+    ],
+    "beaker-options": {
+      "helper":       "acceptance/helper.rb",
+      "options_file": "acceptance/options/openvox.rb"
+    },
+    "os-add": [],
+    "vms": [
+      {
+        "role": "primary",
+        "count": 1,
+        "cpus": 4,
+        "mem_mb": 8192
+      },
+      {
+        "role": "agent",
+        "count": 1,
+        "cpus": 2,
+        "mem_mb": 4096
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Short description

This changeset re-factors `beaker_acceptance.yml` to use `platforms.json` as the source of truth when generating acceptance test matrices. This allows both OpenVox 8.x and OpenVox 9.x to be tested against appropriate platform lists, based on the `openvox-collection` input. Agents without a corresponding server build in 9.x, e.g. Debian 12, are tested against Debian 13.

This re-factor also extracts some of the logic in the GitHub actions workflow to files in the `scripts/` directory. These can be run outside of GitHub Actions to facilitate development and debugging of the test suite.

The first script is `project-config.sh`, which takes acceptance suite being run, the collection being tested, reads `platform.json` and `scripts/project_defaults.json` to generate data used by the `set-project-defaults` workflow step:

```sh
./scripts/project-config.sh openvox openvox9 | jq .
```

The next script is `build-job-matrix.sh`, which takes the suite being run and the collection being tested, calls through to `project-config.sh`, and then generates the job matrix used by the `set-matrix` workflow step:

```sh
./scripts/build-job-matrix.sh openvox openvox9 |jq .
```

The final script is `build-cluster-topology.sh`, which takes the suite being run, the collection being tested, and the OS being tested, calls through to `project-config.sh`, and then generates the test cluster configuration used by the `jpartlow/nested_vms` action:

```sh
./scripts/build-cluster-topology.sh openvox openvox9 debian 12 |jq .
```

An example of the acceptance tests passing for 8.x releases of OpenVox packages:

https://github.com/Sharpie/acceptance-pipelines/actions/runs/29165407943

And an example of the acceptance tests passing for 9.x pre-releases of OpenVox packages:

https://github.com/Sharpie/acceptance-pipelines/actions/runs/29163752031


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
