### PR TITLE
Take Java version as an input for Clojure builds

### DIFF
--- a/.github/workflows/clojure_release.yml
+++ b/.github/workflows/clojure_release.yml
@@ -9,6 +9,11 @@ on:
         type: string
         required: false
         default: ''
+      java-version:
+        description: 'The java version to use when building the jar.'
+        type: string
+        required: false
+        default: '17'
     secrets:
       github_pat:
         # Provide a fine-grained token with the following repository permissions:
@@ -52,7 +57,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
-          java-version: '17'
+          java-version: ${{ inputs.java-version }}
           distribution: temurin
 
       - name: Install clojure tools


### PR DESCRIPTION
### Short description

This commit adds an optional `java-version` input that can be used to select the version of Java used to run a Clojure build. This is required in order to build JAR files containing JRuby 10.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
