### PR TITLE
Munge pre-release versions in Vanagon builds

### DIFF
--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -267,7 +267,16 @@ jobs:
         run: |-
           rm -rf output
           DESCRIBE=$(git describe --abbrev=9)
-          echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
+
+          case "${DESCRIBE}" in
+            *-alpha[0-9]|*-beta[0-9]|*-rc[0-9])
+              printf 'describe=%s\n' "$(sed 's/-/~/' <<<"$DESCRIBE")" >>$GITHUB_OUTPUT
+              ;;
+            *)
+              printf 'describe=%s\n' "${DESCRIBE//-/.}" >>$GITHUB_OUTPUT
+              ;;
+          esac
+
           bundle exec rake "vox:build[${PROJECT_NAME},${BUILD_PLATFORM}]"
 
       - name: Upload build artifacts


### PR DESCRIPTION
### Short description

PR OpenVoxProject/vanagon#95 updated Vanagon's handling of Git tags. If the tag matches a semver.org pre-release with "alpha", "beta" or "rc" as the pre-release identifier, then the "-" in the version string is substituted for "~". That is, a tag like `9.0.0-beta1` becomes the following package version: `9.0.0~beta1`

This is done because the `dpkg` and `rpm` package managers treat `~` specially and sort any version strings containing it before all other strings. This changes allows a `9.0.0~alpha1` package to upgrade to `9.0.0~beta1`, and then to `9.0.0~rc0`, and finally to `9.0.0`.

This commit updates the munging logic in the `build_vanagon.yml` workflow to correctly pass these versions to `rake vox:upload`.

See: https://semver.org
See: https://manpages.debian.org/bookworm/dpkg-dev/deb-version.7.en.html#Sorting_algorithm
See: https://rpm.org/docs/6.0.x/man/rpm-version.7#Comparing

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
