### PR TITLE
Configure CA trust for OSUOSL S3

### DIFF
--- a/.github/actions/setup-osuosl-ca/action.yml
+++ b/.github/actions/setup-osuosl-ca/action.yml
@@ -1,0 +1,52 @@
+---
+name: Configure OSUOSL CA Certificate
+description: >-
+  In July 2026, OSUOSL switched to using a TLS Certificate with a trust
+  chain rooted at "emSign Root CA - G1". This poses a problem as the
+  AWS CLI currently vendors an old CA bundle generated in 2018 that does
+  not include this CA cert:
+
+    https://github.com/aws/aws-cli/issues/10389
+
+  This action writes the emSign CA certificate out to a file and then
+  sets the path to that file in the AWS_CA_BUNDLE environment variable.
+  The AWS CLI will read certificates from this variable, unless overriden
+  by something like the "--ca-bundle" CLI flag.
+
+runs:
+  using: composite
+  steps:
+    - name: Set Up OSUOSL CA Certificate
+      shell: bash
+      run: |
+        # Replace any backslashes with forward slashes so that a Windows path
+        # is usable from both POSIX and WIN32 contexts.
+        osuosl_ca="${RUNNER_TMP//\\//}/osuosl-ca.pem"
+
+        printf 'Writing OSUOSL CA bundle to: %s\n' "${osuosl_ca}"
+
+        cat <<'EOF' >"${osuosl_ca}"
+        emSign Root CA - G1
+        ===================
+        -----BEGIN CERTIFICATE-----
+        MIIDlDCCAnygAwIBAgIKMfXkYgxsWO3W2DANBgkqhkiG9w0BAQsFADBnMQswCQYDVQQGEwJJTjET
+        MBEGA1UECxMKZW1TaWduIFBLSTElMCMGA1UEChMcZU11ZGhyYSBUZWNobm9sb2dpZXMgTGltaXRl
+        ZDEcMBoGA1UEAxMTZW1TaWduIFJvb3QgQ0EgLSBHMTAeFw0xODAyMTgxODMwMDBaFw00MzAyMTgx
+        ODMwMDBaMGcxCzAJBgNVBAYTAklOMRMwEQYDVQQLEwplbVNpZ24gUEtJMSUwIwYDVQQKExxlTXVk
+        aHJhIFRlY2hub2xvZ2llcyBMaW1pdGVkMRwwGgYDVQQDExNlbVNpZ24gUm9vdCBDQSAtIEcxMIIB
+        IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk0u76WaK7p1b1TST0Bsew+eeuGQzf2N4aLTN
+        LnF115sgxk0pvLZoYIr3IZpWNVrzdr3YzZr/k1ZLpVkGoZM0Kd0WNHVO8oG0x5ZOrRkVUkr+PHB1
+        cM2vK6sVmjM8qrOLqs1D/fXqcP/tzxE7lM5OMhbTI0Aqd7OvPAEsbO2ZLIvZTmmYsvePQbAyeGHW
+        DV/D+qJAkh1cF+ZwPjXnorfCYuKrpDhMtTk1b+oDafo6VGiFbdbyL0NVHpENDtjVaqSW0RM8LHhQ
+        6DqS0hdW5TUaQBw+jSztOd9C4INBdN+jzcKGYEho42kLVACL5HZpIQ15TjQIXhTCzLG3rdd8cIrH
+        hQIDAQABo0IwQDAdBgNVHQ4EFgQU++8Nhp6w492pufEhF38+/PB3KxowDgYDVR0PAQH/BAQDAgEG
+        MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAFn/8oz1h31xPaOfG1vR2vjTnGs2
+        vZupYeveFix0PZ7mddrXuqe8QhfnPZHr5X3dPpzxz5KsbEjMwiI/aTvFthUvozXGaCocV685743Q
+        NcMYDHsAVhzNixl03r4PEuDQqqE/AjSxcM6dGNYIAwlG7mDgfrbESQRRfXBgvKqy/3lyeqYdPV8q
+        +Mri/Tm3R7nrft8EI6/6nAYH6ftjk4BAtcZsCjEozgyfz7MjNYBBjWzEN3uBL4ChQEKF6dk4jeih
+        U80Bv2noWgbyRQuQ+q7hv53yrlc8pa6yVvSLZUDp/TGBLPQ5Cdjua6e0ph0VpZj3AYHYhX3zUVxx
+        iN66zB+Afko=
+        -----END CERTIFICATE-----
+        EOF
+
+        printf 'AWS_CA_BUNDLE=%s' "${osuosl_ca}" >>$GITHUB_ENV

--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -116,6 +116,10 @@ jobs:
           rm -rf output
           bundle exec rake "vox:build[${BUILD_REF}]"
 
+      - name: Configure OSUOSL CA Certificate for S3
+        if: contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+        uses: ./.github/actions/setup-osuosl-ca
+
       - name: Upload output to S3
         run: |
           bundle exec rake vox:upload

--- a/.github/workflows/build_ezbake_fips.yml
+++ b/.github/workflows/build_ezbake_fips.yml
@@ -111,6 +111,10 @@ jobs:
           rm -rf output
           bundle exec rake "vox:build[${BUILD_REF}]"
 
+      - name: Configure OSUOSL CA Certificate for S3
+        if: contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+        uses: ./.github/actions/setup-osuosl-ca
+
       - name: Upload output to S3
         run: |
           bundle exec rake vox:upload

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -285,6 +285,12 @@ jobs:
           name: build-artifacts-${{ steps.build.outputs.describe }}-${{ matrix.platform }}
           path: ${{ inputs.working_directory }}/output/
 
+      - name: Configure OSUOSL CA Certificate for S3
+        if: >-
+          inputs.upload_to_s3 &&
+          contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+        uses: ./.github/actions/setup-osuosl-ca
+
       - name: Upload output to S3
         if: ${{ inputs.upload_to_s3 }}
         working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
### Short description

In July 2026, OSUOSL switched to using a TLS Certificate with a trust chain rooted at "emSign Root CA - G1". This poses a problem as the AWS CLI currently vendors an old CA bundle generated in 2018 that does not include this CA cert.

This commit adds a new action, setup-osuosl-ca, that writes the emSign CA certificate out to a file under `$RUNNER_TMP` and then sets the path to that file in the AWS_CA_BUNDLE environment variable. The AWS CLI will read certificates from this variable, unless overridden by something like the "--ca-bundle" CLI flag.

Ref: https://github.com/aws/aws-cli/issues/10389

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)