### PR TITLE
Fix quotes in guard clauses for s3.osuosl.org

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -117,7 +117,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        if: contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+        if: contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3

--- a/.github/workflows/build_ezbake_fips.yml
+++ b/.github/workflows/build_ezbake_fips.yml
@@ -112,7 +112,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        if: contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+        if: contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Configure OSUOSL CA Certificate for S3
         if: >-
           inputs.upload_to_s3 &&
-          contains(secrets.S3_ENDPOINT_URL, "s3.osuosl.org")
+          contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3


### PR DESCRIPTION
### Short description

Commit 637eec7c69f0a82d632a6ed66facb5d31effe8aa added logic for swapping in the OSUOSL CA certificate to the various build workflows. This swap is guarded by a conditional check that the S3 endpoint in use is "s3.osuosl.org" as the swap reduces the CA trust list to a single entry.

This commit corrects the use of double quotes in the conditional as GitHub actions syntax only allows single quotes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
