### PR TITLE
Use string equality to detect s3.osuosl.org

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -117,7 +117,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        if: contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
+        if: ( secrets.S3_ENDPOINT_URL == 'https://s3.osuosl.org' )
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3

--- a/.github/workflows/build_ezbake_fips.yml
+++ b/.github/workflows/build_ezbake_fips.yml
@@ -112,7 +112,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        if: contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
+        if: ( secrets.S3_ENDPOINT_URL == 'https://s3.osuosl.org' )
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Configure OSUOSL CA Certificate for S3
         if: >-
           inputs.upload_to_s3 &&
-          contains(secrets.S3_ENDPOINT_URL, 's3.osuosl.org')
+          ( secrets.S3_ENDPOINT_URL == 'https://s3.osuosl.org' )
         uses: ./.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3


### PR DESCRIPTION
### Short description

The `S3_ENDPOINT_URL` is currently set in GitHub Actions workflows as a Secret, even though the URL value is not sensitive in any way. Unfortunately, this restricts which operations can be performed in an `if:` statement. Function calls are disallowed, so this commit swaps use of `contains()` for a string equality match.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
