### PR TITLE
Fix reference to setup-osuosl-ca action

### DIFF
--- a/.github/workflows/build_ezbake.yml
+++ b/.github/workflows/build_ezbake.yml
@@ -117,7 +117,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        uses: ./.github/actions/setup-osuosl-ca
+        uses: $/.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3
         run: |

--- a/.github/workflows/build_ezbake_fips.yml
+++ b/.github/workflows/build_ezbake_fips.yml
@@ -112,7 +112,7 @@ jobs:
           bundle exec rake "vox:build[${BUILD_REF}]"
 
       - name: Configure OSUOSL CA Certificate for S3
-        uses: ./.github/actions/setup-osuosl-ca
+        uses: $/.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3
         run: |

--- a/.github/workflows/build_vanagon.yml
+++ b/.github/workflows/build_vanagon.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Configure OSUOSL CA Certificate for S3
         if: ${{ inputs.upload_to_s3 }}
-        uses: ./.github/actions/setup-osuosl-ca
+        uses: $/.github/actions/setup-osuosl-ca
 
       - name: Upload output to S3
         if: ${{ inputs.upload_to_s3 }}


### PR DESCRIPTION
### Short description

Configuring `uses: ./<path>` is the syntax for calling up a re-usable workflow within the same repository. Calling up a re-usable action requires a slightly different invocation: `uses: $/<path>`

Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow-at-the-running-commit-recommended

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
