### PR TITLE
Fix reference to RUNNER_TEMP in setup-osuosl-ca

### DIFF
--- a/.github/actions/setup-osuosl-ca/action.yml
+++ b/.github/actions/setup-osuosl-ca/action.yml
@@ -9,7 +9,7 @@ description: >-
     https://github.com/aws/aws-cli/issues/10389
 
   This action downloads the latest Mozilla CA bundle, writes it out to a file
-  under $RUNNER_TMP, and then sets the path to that file in the AWS_CA_BUNDLE
+  under $RUNNER_TEMP, and then sets the path to that file in the AWS_CA_BUNDLE
   environment variable. The AWS CLI will read certificates from this variable,
   unless overriden by something like the "--ca-bundle" CLI flag.
 
@@ -21,7 +21,7 @@ runs:
       run: |
         # Replace any backslashes with forward slashes so that a Windows path
         # is usable from both POSIX and WIN32 contexts.
-        osuosl_ca="${RUNNER_TMP//\\//}/osuosl-ca.pem"
+        osuosl_ca="${RUNNER_TEMP//\\//}/osuosl-ca.pem"
 
         printf 'Downloading Mozilla CA bundle to: %s\n' "${osuosl_ca}"
 


### PR DESCRIPTION
### Short description

Prior to this commit, the incorrect `RUNNER_TMP` name was used.

Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
